### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -41,7 +41,7 @@ def _check_call_py24(cmd, *args, **kwargs):
     class CalledProcessError(Exception):
         pass
     if not res == 0:
-        msg = "Command '%s' return non-zero exit status %d" % (cmd, res)
+        msg = "Command '{0!s}' return non-zero exit status {1:d}".format(cmd, res)
         raise CalledProcessError(msg)
 vars(subprocess).setdefault('check_call', _check_call_py24)
 
@@ -103,8 +103,7 @@ def _build_egg(egg, tarball, to_dir):
 
 
 def _do_download(version, download_base, to_dir, download_delay):
-    egg = os.path.join(to_dir, 'setuptools-%s-py%d.%d.egg'
-                       % (version, sys.version_info[0], sys.version_info[1]))
+    egg = os.path.join(to_dir, 'setuptools-{0!s}-py{1:d}.{2:d}.egg'.format(version, sys.version_info[0], sys.version_info[1]))
     if not os.path.exists(egg):
         tarball = download_setuptools(version, download_base,
                                       to_dir, download_delay)
@@ -160,7 +159,7 @@ def download_file_powershell(url, target):
     cmd = [
         'powershell',
         '-Command',
-        "(new-object System.Net.WebClient).DownloadFile(%(url)r, %(target)r)" % vars(),
+        "(new-object System.Net.WebClient).DownloadFile({url!r}, {target!r})".format(**vars()),
     ]
     subprocess.check_call(cmd)
 
@@ -269,7 +268,7 @@ def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     """
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    tgz_name = "setuptools-%s.tar.gz" % version
+    tgz_name = "setuptools-{0!s}.tar.gz".format(version)
     url = download_base + tgz_name
     saveto = os.path.join(to_dir, tgz_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads
@@ -323,7 +322,7 @@ def _extractall(self, path=".", members=None):
             if self.errorlevel > 1:
                 raise
             else:
-                self._dbg(1, "tarfile: %s" % e)
+                self._dbg(1, "tarfile: {0!s}".format(e))
 
 
 def _build_install_args(options):

--- a/generate_user_files.py
+++ b/generate_user_files.py
@@ -69,11 +69,11 @@ def change_base_dir():
         return new_base
 
     msg = wrap(u"""WARNING: Your user files will be created in the directory
-'%(new_base)s' you have chosen. To access these files, you will either have
-to use the argument "-dir:%(new_base)s" every time you run the bot, or set
+'{new_base!s}' you have chosen. To access these files, you will either have
+to use the argument "-dir:{new_base!s}" every time you run the bot, or set
 the environment variable "PYWIKIBOT2_DIR" equal to this directory name in
 your operating system. See your operating system documentation for how to
-set environment variables.""" % {'new_base': new_base}, width=76)
+set environment variables.""".format(**{'new_base': new_base}), width=76)
     for line in msg:
         pywikibot.output(line)
     if pywikibot.input_yn('Is this OK?', default=False, automatic_quit=False):
@@ -85,7 +85,7 @@ set environment variables.""" % {'new_base': new_base}, width=76)
 def file_exists(filename):
     """Return whether the file exists and print a message if it exists."""
     if os.path.exists(filename):
-        pywikibot.output(u"'%s' already exists." % filename)
+        pywikibot.output(u"'{0!s}' already exists.".format(filename))
         return True
     return False
 
@@ -272,8 +272,7 @@ def create_user_config(args=None, force=False):
 
         config_text = '\n'.join(res)
         if len(config_text.splitlines()) < 350:
-            warn('Extended config extraction too short: %d'
-                 % len(config_text.splitlines()),
+            warn('Extended config extraction too short: {0:d}'.format(len(config_text.splitlines())),
                  UserWarning)
 
         config_content = EXTENDED_CONFIG
@@ -292,7 +291,7 @@ def create_user_config(args=None, force=False):
                                           usernames=usernames,
                                           config_text=config_text))
 
-        pywikibot.output(u"'%s' written." % _fnc)
+        pywikibot.output(u"'{0!s}' written.".format(_fnc))
     except:
         try:
             os.remove(_fnc)
@@ -322,7 +321,7 @@ def main(*args):
 
     local_args = pywikibot.handle_args(args)
     if local_args:
-        pywikibot.output('Unknown arguments: %s' % ' '.join(local_args))
+        pywikibot.output('Unknown arguments: {0!s}'.format(' '.join(local_args)))
         return False
 
     if config.mylang is not None:
@@ -340,7 +339,7 @@ def main(*args):
     # in the directory. This will repeat if user-config.py also exists in
     # the requested directory.
     if not force or config.verbose_output:
-        pywikibot.output(u'\nYour default user directory is "%s"' % base_dir)
+        pywikibot.output(u'\nYour default user directory is "{0!s}"'.format(base_dir))
         while os.path.isfile(os.path.join(base_dir, "user-config.py")):
             pywikibot.output('user-config.py already exists'
                              ' in the target directory.')

--- a/pwb.py
+++ b/pwb.py
@@ -157,7 +157,7 @@ try:
         print("requests import problem: requests.__version__ does not exist.")
         requests = None
 except ImportError as e:
-    print("ImportError: %s" % e)
+    print("ImportError: {0!s}".format(e))
     requests = None
 
 if not requests:
@@ -220,7 +220,7 @@ def main():
             if os.path.exists(testpath):
                 filename = testpath
             else:
-                raise OSError("%s not found!" % filename)
+                raise OSError("{0!s} not found!".format(filename))
 
         # When both pwb.py and the filename to run are within the current
         # working directory:
@@ -244,8 +244,7 @@ def main():
             try:
                 __import__(file_package)
             except ImportError as e:
-                warn('Parent module %s not found: %s'
-                     % (file_package, e), ImportWarning)
+                warn('Parent module {0!s} not found: {1!s}'.format(file_package, e), ImportWarning)
 
         run_python_file(filename, [filename] + args, argvu, file_package)
         return True

--- a/pywikibot/__init__.py
+++ b/pywikibot/__init__.py
@@ -291,8 +291,7 @@ class Coordinate(_WbRepresentation):
         """
         if self.globe not in self.site.globes():
             raise CoordinateGlobeUnknownException(
-                u"%s is not supported in Wikibase yet."
-                % self.globe)
+                u"{0!s} is not supported in Wikibase yet.".format(self.globe))
         return {'latitude': self.lat,
                 'longitude': self.lon,
                 'altitude': self.alt,
@@ -506,7 +505,7 @@ class WbTime(_WbRepresentation):
             elif precision in self.PRECISION:
                 self.precision = self.PRECISION[precision]
             else:
-                raise ValueError('Invalid precision: "%s"' % precision)
+                raise ValueError('Invalid precision: "{0!s}"'.format(precision))
 
     @classmethod
     def fromTimestr(cls, datetimestr, precision=14, before=0, after=0,
@@ -541,7 +540,7 @@ class WbTime(_WbRepresentation):
         match = re.match(r'([-+]?\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)Z',
                          datetimestr)
         if not match:
-            raise ValueError(u"Invalid format: '%s'" % datetimestr)
+            raise ValueError(u"Invalid format: '{0!s}'".format(datetimestr))
         t = match.groups()
         return cls(long(t[0]), int(t[1]), int(t[2]),
                    int(t[3]), int(t[4]), int(t[5]),
@@ -806,18 +805,16 @@ def Site(code=None, fam=None, user=None, sysop=None, interface=None, url=None):
             raise ValueError('Invalid interface name: {0}'.format(interface))
 
     if not issubclass(interface, BaseSite):
-        warning('Site called with interface=%s' % interface.__name__)
+        warning('Site called with interface={0!s}'.format(interface.__name__))
 
     user = normalize_username(user)
-    key = '%s:%s:%s:%s' % (interface.__name__, fam, code, user)
+    key = '{0!s}:{1!s}:{2!s}:{3!s}'.format(interface.__name__, fam, code, user)
     if key not in _sites or not isinstance(_sites[key], interface):
         _sites[key] = interface(code=code, fam=fam, user=user, sysop=sysop)
-        debug(u"Instantiated %s object '%s'"
-              % (interface.__name__, _sites[key]), _logger)
+        debug(u"Instantiated {0!s} object '{1!s}'".format(interface.__name__, _sites[key]), _logger)
 
         if _sites[key].code != code:
-            warn('Site %s instantiated using different code "%s"'
-                 % (_sites[key], code), UserWarning, 2)
+            warn('Site {0!s} instantiated using different code "{1!s}"'.format(_sites[key], code), UserWarning, 2)
 
     return _sites[key]
 

--- a/pywikibot/bot.py
+++ b/pywikibot/bot.py
@@ -108,8 +108,7 @@ if not PY2:
 
 # User interface initialization
 # search for user interface module in the 'userinterfaces' subdirectory
-uiModule = __import__("pywikibot.userinterfaces.%s_interface"
-                      % config.userinterface,
+uiModule = __import__("pywikibot.userinterfaces.{0!s}_interface".format(config.userinterface),
                       fromlist=['UI'])
 ui = uiModule.UI()
 pywikibot.argvu = ui.argvu()
@@ -245,7 +244,7 @@ def init_handlers(strm=None):
         if config.logfilename:
             logfile = config.datafilepath("logs", config.logfilename)
         else:
-            logfile = config.datafilepath("logs", "%s-bot.log" % moduleName)
+            logfile = config.datafilepath("logs", "{0!s}-bot.log".format(moduleName))
         file_handler = RotatingFileHandler(filename=logfile,
                                            maxBytes=1024 * config.logfilesize,
                                            backupCount=config.logfilecount)
@@ -294,12 +293,12 @@ def writelogheader():
     log(u'COMMAND: {0}'.format(sys.argv))
 
     # script call time stamp
-    log(u'DATE: %s UTC' % str(datetime.datetime.utcnow()))
+    log(u'DATE: {0!s} UTC'.format(str(datetime.datetime.utcnow())))
 
     # new framework release/revision? (handleArgs needs to be called first)
     try:
-        log(u'VERSION: %s' %
-            version.getversion(online=config.log_pywiki_repo_version).strip())
+        log(u'VERSION: {0!s}'.format(
+            version.getversion(online=config.log_pywiki_repo_version).strip()))
     except version.ParseError:
         exception()
 
@@ -308,7 +307,7 @@ def writelogheader():
         log(u'SYSTEM: {0}'.format(os.uname()))
 
     # config file dir
-    log(u'CONFIG FILE DIR: %s' % pywikibot.config2.base_dir)
+    log(u'CONFIG FILE DIR: {0!s}'.format(pywikibot.config2.base_dir))
 
     all_modules = sys.modules.keys()
 
@@ -336,9 +335,9 @@ def writelogheader():
         if 'ver' not in info:
             info['ver'] = '??'
         if 'err' in info:
-            log(u'  %(name)s: %(err)s' % info)
+            log(u'  {name!s}: {err!s}'.format(**info))
         else:
-            log(u'  %(name)s (%(path)s) = %(ver)s' % info)
+            log(u'  {name!s} ({path!s}) = {ver!s}'.format(**info))
 
     # imported modules
     log(u'MODULES:')
@@ -352,7 +351,7 @@ def writelogheader():
             log(u'  {0} {1} {2}'.format(filename, ver[:7], mtime.isoformat(str(' '))))
 
     if config.log_pywiki_repo_version:
-        log(u'PYWIKI REPO VERSION: %s' % version.getversion_onlinerepo())
+        log(u'PYWIKI REPO VERSION: {0!s}'.format(version.getversion_onlinerepo()))
 
     log(u'=== ' * 14)
 
@@ -863,8 +862,7 @@ def handle_args(args=None, do_help=True):
             config.log = []
         elif option in ('-cosmeticchanges', '-cc'):
             config.cosmetic_changes = not config.cosmetic_changes
-            output(u'NOTE: option cosmetic_changes is %s\n'
-                   % config.cosmetic_changes)
+            output(u'NOTE: option cosmetic_changes is {0!s}\n'.format(config.cosmetic_changes))
         elif option == '-simulate':
             config.simulate = True
         #
@@ -934,12 +932,12 @@ def handle_args(args=None, do_help=True):
         m = re.search(r"\$Id"
                       r": (\w+) \$", pywikibot.__version__)
         if m:
-            pywikibot.output(u'Pywikibot r%s' % m.group(1))
+            pywikibot.output(u'Pywikibot r{0!s}'.format(m.group(1)))
         else:
             # Version ID not available on SVN repository.
             # Maybe this information should be imported from version.py
             pywikibot.output(u'Pywikibot SVN repository')
-        pywikibot.output(u'Python %s' % sys.version)
+        pywikibot.output(u'Python {0!s}'.format(sys.version))
 
     if do_help:
         showHelp()
@@ -988,7 +986,7 @@ Global arguments available for all bots:
 -help             Show this help text.
 
 -log              Enable the log file, using the default filename
-                  '%s-bot.log'
+                  '{0!s}-bot.log'
                   Logs will be stored in the logs subdirectory.
 
 -log:xyz          Enable the log file, using 'xyz' as the filename.
@@ -1021,9 +1019,9 @@ Global arguments available for all bots:
 -<config var>:n   You may use all given numeric config variables as option and
                   modify it with command line.
 
-''' % module_name
+'''.format(module_name)
     try:
-        module = __import__('%s' % module_name)
+        module = __import__('{0!s}'.format(module_name))
         helpText = module.__doc__
         if PY2 and isinstance(helpText, bytes):
             helpText = helpText.decode('utf-8')
@@ -1033,7 +1031,7 @@ Global arguments available for all bots:
         pywikibot.stdout(helpText)  # output to STDOUT
     except Exception:
         if module_name:
-            pywikibot.stdout(u'Sorry, no help available for %s' % module_name)
+            pywikibot.stdout(u'Sorry, no help available for {0!s}'.format(module_name))
         pywikibot.log('showHelp:', exc_info=True)
     pywikibot.stdout(globalHelp)
 
@@ -1088,7 +1086,7 @@ def writeToCommandLogFile():
     """
     modname = calledModuleName()
     # put quotation marks around all parameters
-    args = [modname] + [u'"%s"' % s for s in pywikibot.argvu[1:]]
+    args = [modname] + [u'"{0!s}"'.format(s) for s in pywikibot.argvu[1:]]
     command_log_filename = config.datafilepath('logs', 'commands.log')
     try:
         command_log_file = codecs.open(command_log_filename, 'a', 'utf-8')
@@ -1096,8 +1094,7 @@ def writeToCommandLogFile():
         command_log_file = codecs.open(command_log_filename, 'w', 'utf-8')
     # add a timestamp in ISO 8601 formulation
     isoDate = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
-    command_log_file.write('%s r%s Python %s '
-                           % (isoDate, version.getversiondict()['rev'],
+    command_log_file.write('{0!s} r{1!s} Python {2!s} '.format(isoDate, version.getversiondict()['rev'],
                               sys.version.split()[0]))
     s = u' '.join(args)
     command_log_file.write(s + os.linesep)
@@ -1169,8 +1166,7 @@ class BaseBot(object):
             self.options[opt] = kwargs[opt]
 
         for opt in receivedOptions - validOptions:
-            pywikibot.warning(u'%s is not a valid option. It was ignored.'
-                              % opt)
+            pywikibot.warning(u'{0!s} is not a valid option. It was ignored.'.format(opt))
 
     def getOption(self, option):
         """
@@ -1181,7 +1177,7 @@ class BaseBot(object):
         try:
             return self.options.get(option, self.availableOptions[option])
         except KeyError:
-            raise pywikibot.Error(u'%s is not a valid bot option.' % option)
+            raise pywikibot.Error(u'{0!s} is not a valid bot option.'.format(option))
 
     @property
     def current_page(self):
@@ -1203,7 +1199,7 @@ class BaseBot(object):
         """
         if page != self._current_page:
             self._current_page = page
-            msg = u'Working on %r' % page.title()
+            msg = u'Working on {0!r}'.format(page.title())
             if config.colorized_output:
                 log(msg)
                 stdout(color_format('\n\n>>> {lightpurple}{0}{default} <<<',
@@ -1260,8 +1256,7 @@ class BaseBot(object):
         @rtype: bool
         """
         if oldtext == newtext:
-            pywikibot.output(u'No changes were needed on %s'
-                             % page.title(asLink=True))
+            pywikibot.output(u'No changes were needed on {0!s}'.format(page.title(asLink=True)))
             return
 
         self.current_page = page
@@ -1272,7 +1267,7 @@ class BaseBot(object):
             pywikibot.showDiff(oldtext, newtext)
 
         if 'summary' in kwargs:
-            pywikibot.output(u'Edit summary: %s' % kwargs['summary'])
+            pywikibot.output(u'Edit summary: {0!s}'.format(kwargs['summary']))
 
         page.text = newtext
         return self._save_page(page, page.save, **kwargs)
@@ -1311,24 +1306,19 @@ class BaseBot(object):
             if not ignore_save_related_errors:
                 raise
             if isinstance(e, pywikibot.EditConflict):
-                pywikibot.output(u'Skipping %s because of edit conflict'
-                                 % page.title())
+                pywikibot.output(u'Skipping {0!s} because of edit conflict'.format(page.title()))
             elif isinstance(e, pywikibot.SpamfilterError):
                 pywikibot.output(
-                    u'Cannot change %s because of blacklist entry %s'
-                    % (page.title(), e.url))
+                    u'Cannot change {0!s} because of blacklist entry {1!s}'.format(page.title(), e.url))
             elif isinstance(e, pywikibot.LockedPage):
-                pywikibot.output(u'Skipping %s (locked page)'
-                                 % page.title())
+                pywikibot.output(u'Skipping {0!s} (locked page)'.format(page.title()))
             else:
                 pywikibot.error(
-                    u'Skipping %s because of a save related error: %s'
-                    % (page.title(), e))
+                    u'Skipping {0!s} because of a save related error: {1!s}'.format(page.title(), e))
         except pywikibot.ServerError as e:
             if not ignore_server_errors:
                 raise
-            pywikibot.error(u'Server Error while processing %s: %s'
-                            % (page.title(), e))
+            pywikibot.error(u'Server Error while processing {0!s}: {1!s}'.format(page.title(), e))
         else:
             return True
         return False
@@ -1356,16 +1346,13 @@ class BaseBot(object):
             else:
                 seconds = delta.seconds + delta.days * 86400
             if delta.days:
-                pywikibot.output("Execution time: %d days, %d seconds"
-                                 % (delta.days, delta.seconds))
+                pywikibot.output("Execution time: {0:d} days, {1:d} seconds".format(delta.days, delta.seconds))
             else:
-                pywikibot.output("Execution time: %d seconds" % delta.seconds)
+                pywikibot.output("Execution time: {0:d} seconds".format(delta.seconds))
             if self._treat_counter:
-                pywikibot.output("Read operation time: %d seconds"
-                                 % (seconds / self._treat_counter))
+                pywikibot.output("Read operation time: {0:d} seconds".format((seconds / self._treat_counter)))
             if self._save_counter:
-                pywikibot.output("Write operation time: %d seconds"
-                                 % (seconds / self._save_counter))
+                pywikibot.output("Write operation time: {0:d} seconds".format((seconds / self._save_counter)))
 
         # exc_info contains exception from self.run() while terminating
         exc_info = sys.exc_info()
@@ -1377,8 +1364,7 @@ class BaseBot(object):
 
     def treat(self, page):
         """Process one page (Abstract method)."""
-        raise NotImplementedError('Method %s.treat() not implemented.'
-                                  % self.__class__.__name__)
+        raise NotImplementedError('Method {0!s}.treat() not implemented.'.format(self.__class__.__name__))
 
     def init_page(self, page):
         """Return whether treat should be executed for the page."""
@@ -1388,8 +1374,7 @@ class BaseBot(object):
         """Process all pages in generator."""
         self._start_ts = pywikibot.Timestamp.now()
         if not hasattr(self, 'generator'):
-            raise NotImplementedError('Variable %s.generator not set.'
-                                      % self.__class__.__name__)
+            raise NotImplementedError('Variable {0!s}.generator not set.'.format(self.__class__.__name__))
 
         maxint = 0
         if PY2:
@@ -1419,14 +1404,14 @@ class BaseBot(object):
                         'Python 3 should be used to process very large batches'
                         % (self.__class__.__name__, sys.maxint))
         except QuitKeyboardInterrupt:
-            pywikibot.output('\nUser quit %s bot run...' %
-                             self.__class__.__name__)
+            pywikibot.output('\nUser quit {0!s} bot run...'.format(
+                             self.__class__.__name__))
         except KeyboardInterrupt:
             if config.verbose_output:
                 raise
             else:
-                pywikibot.output('\nKeyboardInterrupt during %s bot run...' %
-                                 self.__class__.__name__)
+                pywikibot.output('\nKeyboardInterrupt during {0!s} bot run...'.format(
+                                 self.__class__.__name__))
         finally:
             self.exit()
 
@@ -1457,7 +1442,7 @@ class Bot(BaseBot):
         if not self._site:
             warning('Bot.site was not set before being retrieved.')
             self.site = pywikibot.Site()
-            warning('Using the default site: %s' % self.site)
+            warning('Using the default site: {0!s}'.format(self.site))
         return self._site
 
     @site.setter
@@ -1473,15 +1458,13 @@ class Bot(BaseBot):
             return
 
         if site not in self._sites:
-            log(u'LOADING SITE %s VERSION: %s'
-                % (site, site.version()))
+            log(u'LOADING SITE {0!s} VERSION: {1!s}'.format(site, site.version()))
 
             self._sites.add(site)
             if len(self._sites) == 2:
-                log('%s uses multiple sites' % self.__class__.__name__)
+                log('{0!s} uses multiple sites'.format(self.__class__.__name__))
         if self._site and self._site != site:
-            log('%s: changing site from %s to %s'
-                % (self.__class__.__name__, self._site, site))
+            log('{0!s}: changing site from {1!s} to {2!s}'.format(self.__class__.__name__, self._site, site))
         self._site = site
 
     def run(self):
@@ -1498,8 +1481,7 @@ class Bot(BaseBot):
                 '%s.__init__ set the Bot.site property; this is only needed '
                 'when the Bot accesses many sites.' % self.__class__.__name__)
         else:
-            log('Bot is managing the %s.site property in run()'
-                % self.__class__.__name__)
+            log('Bot is managing the {0!s}.site property in run()'.format(self.__class__.__name__))
         super(Bot, self).run()
 
     def init_page(self, page):
@@ -1617,8 +1599,7 @@ class CurrentPageBot(BaseBot):
 
     def treat_page(self):
         """Process one page (Abstract method)."""
-        raise NotImplementedError('Method %s.treat_page() not implemented.'
-                                  % self.__class__.__name__)
+        raise NotImplementedError('Method {0!s}.treat_page() not implemented.'.format(self.__class__.__name__))
 
     def treat(self, page):
         """Set page to current page and treat that page."""
@@ -1794,7 +1775,7 @@ class WikidataBot(Bot):
         self.repo = self.site.data_repository()
         if self.repo is None:
             raise pywikibot.exceptions.WikiBaseError(
-                '%s is not connected to a data repository' % self.site)
+                '{0!s} is not connected to a data repository'.format(self.site))
 
     def cacheSources(self):
         """
@@ -1823,8 +1804,7 @@ class WikidataBot(Bot):
         for page in self.site.search(property_name, total=1, namespaces=ns):
             page = pywikibot.PropertyPage(self.site.data_repository(),
                                           page.title())
-            pywikibot.output(u"Assuming that %s property is %s." %
-                             (property_name, page.id))
+            pywikibot.output(u"Assuming that {0!s} property is {1!s}.".format(property_name, page.id))
             return page.id
         return pywikibot.input(u'Property %s was not found. Please enter the '
                                u'property ID (e.g. P123) of it:'
@@ -1862,7 +1842,7 @@ class WikidataBot(Bot):
             pywikibot.output(json.dumps(diff, indent=4, sort_keys=True))
 
         if 'summary' in kwargs:
-            pywikibot.output(u'Change summary: %s' % kwargs['summary'])
+            pywikibot.output(u'Change summary: {0!s}'.format(kwargs['summary']))
 
         # TODO async in editEntity should actually have some effect (bug T86074)
         # TODO PageSaveRelatedErrors should be actually raised in editEntity
@@ -1887,15 +1867,14 @@ class WikidataBot(Bot):
     def run(self):
         """Process all pages in generator."""
         if not hasattr(self, 'generator'):
-            raise NotImplementedError('Variable %s.generator not set.'
-                                      % self.__class__.__name__)
+            raise NotImplementedError('Variable {0!s}.generator not set.'.format(self.__class__.__name__))
 
         treat_missing_item = hasattr(self, 'treat_missing_item')
 
         try:
             for page in self.generator:
                 if not page.exists():
-                    pywikibot.output('%s doesn\'t exist.' % page)
+                    pywikibot.output('{0!s} doesn\'t exist.'.format(page))
                 # FIXME: Hack because 'is_data_repository' doesn't work if
                 #        site is the APISite. See T85483
                 data_site = page.site.data_repository()
@@ -1919,18 +1898,18 @@ class WikidataBot(Bot):
                 if not item:
                     if not treat_missing_item:
                         pywikibot.output(
-                            '%s doesn\'t have a wikidata item.' % page)
+                            '{0!s} doesn\'t have a wikidata item.'.format(page))
                         # TODO: Add an option to create the item
                         continue
                 self.treat(page, item)
         except QuitKeyboardInterrupt:
-            pywikibot.output('\nUser quit %s bot run...' %
-                             self.__class__.__name__)
+            pywikibot.output('\nUser quit {0!s} bot run...'.format(
+                             self.__class__.__name__))
         except KeyboardInterrupt:
             if config.verbose_output:
                 raise
             else:
-                pywikibot.output('\nKeyboardInterrupt during %s bot run...' %
-                                 self.__class__.__name__)
+                pywikibot.output('\nKeyboardInterrupt during {0!s} bot run...'.format(
+                                 self.__class__.__name__))
         except Exception as e:
             pywikibot.exception(msg=e, tb=True)

--- a/pywikibot/botirc.py
+++ b/pywikibot/botirc.py
@@ -63,9 +63,8 @@ class IRCBot(pywikibot.Bot, SingleServerIRCBot):
         self.channel = channel
         self.site = site
         self.other_ns = re.compile(
-            u'\x0314\\[\\[\x0307(%s)'
-            % u'|'.join(item.custom_name for item in site.namespaces.values()
-                        if item != 0))
+            u'\x0314\\[\\[\x0307({0!s})'.format(u'|'.join(item.custom_name for item in site.namespaces.values()
+                        if item != 0)))
         self.api_url = self.site.apipath()
         self.api_url += '?action=query&meta=siteinfo&siprop=statistics&format=xml'
         self.api_found = re.compile(r'articles="(.*?)"')

--- a/pywikibot/comms/http.py
+++ b/pywikibot/comms/http.py
@@ -313,9 +313,8 @@ def _http_process(session, http_request):
     auth = get_authentication(uri)
     if auth is not None and len(auth) == 4:
         if isinstance(requests_oauthlib, ImportError):
-            warn('%s' % requests_oauthlib, ImportWarning)
-            error('OAuth authentication not supported: %s'
-                  % requests_oauthlib)
+            warn('{0!s}'.format(requests_oauthlib), ImportWarning)
+            error('OAuth authentication not supported: {0!s}'.format(requests_oauthlib))
             auth = None
         else:
             auth = requests_oauthlib.OAuth1(*auth)
@@ -352,7 +351,7 @@ def error_handling_callback(request):
         raise request.data
 
     if request.status == 504:
-        raise Server504Error("Server %s timed out" % request.hostname)
+        raise Server504Error("Server {0!s} timed out".format(request.hostname))
 
     if request.status == 414:
         raise Server414Error('Too long GET request')

--- a/pywikibot/comms/rcstream.py
+++ b/pywikibot/comms/rcstream.py
@@ -82,14 +82,14 @@ class RcListenerThread(threading.Thread):
         self.total = total
         self.count = 0
 
-        debug('Opening connection to %r' % self, _logger)
+        debug('Opening connection to {0!r}'.format(self), _logger)
         self.client = socketIO_client.SocketIO(rchost, rcport)
 
         thread = self
 
         class RCListener(socketIO_client.BaseNamespace):
             def on_change(self, change):
-                debug('Received change %r' % change, _logger)
+                debug('Received change {0!r}'.format(change), _logger)
                 if not thread.running:
                     debug('Thread in shutdown mode; ignoring change.', _logger)
                     return
@@ -97,8 +97,7 @@ class RcListenerThread(threading.Thread):
                 thread.count += 1
                 thread.queue.put(change)
                 if thread.queue.qsize() > thread.warn_queue_length:
-                    warning('%r queue length exceeded %i'
-                            % (thread,
+                    warning('{0!r} queue length exceeded {1:d}'.format(thread,
                                thread.warn_queue_length),
                             _logger=_logger)
                     thread.warn_queue_length = thread.warn_queue_length + 100
@@ -108,14 +107,13 @@ class RcListenerThread(threading.Thread):
                     return
 
             def on_connect(self):
-                debug('Connected to %r; subscribing to %s'
-                      % (thread, thread.wikihost),
+                debug('Connected to {0!r}; subscribing to {1!s}'.format(thread, thread.wikihost),
                       _logger)
                 self.emit('subscribe', thread.wikihost)
-                debug('Subscribed to %s' % thread.wikihost, _logger)
+                debug('Subscribed to {0!s}'.format(thread.wikihost), _logger)
 
             def on_reconnect(self):
-                debug('Reconnected to %r' % (thread,), _logger)
+                debug('Reconnected to {0!r}'.format(thread), _logger)
                 self.on_connect()
 
         class GlobalListener(socketIO_client.BaseNamespace):
@@ -127,7 +125,7 @@ class RcListenerThread(threading.Thread):
 
     def __repr__(self):
         """Return representation."""
-        return "<rcstream for socketio://%s@%s:%s%s>" % (
+        return "<rcstream for socketio://{0!s}@{1!s}:{2!s}{3!s}>".format(
                self.wikihost, self.rchost, self.rcport, self.rcpath
         )
 
@@ -136,9 +134,9 @@ class RcListenerThread(threading.Thread):
         self.running = True
         while self.running:
             self.client.wait(seconds=0.1)
-        debug('Shut down event loop for %r' % self, _logger)
+        debug('Shut down event loop for {0!r}'.format(self), _logger)
         self.client.disconnect()
-        debug('Disconnected %r' % self, _logger)
+        debug('Disconnected {0!r}'.format(self), _logger)
         self.queue.put(None)
 
     def stop(self):
@@ -180,7 +178,7 @@ def rc_listener(wikihost, rchost, rcport=80, rcpath='/rc', total=None):
         total=total
     )
 
-    debug('Starting rcstream thread %r' % rc_thread,
+    debug('Starting rcstream thread {0!r}'.format(rc_thread),
           _logger)
     rc_thread.start()
 

--- a/pywikibot/config2.py
+++ b/pywikibot/config2.py
@@ -321,8 +321,7 @@ def get_base_dir(test_directory=None):
                 elif win_version in (6, 10):
                     sub_dir = ["AppData", "Roaming"]
                 else:
-                    raise WindowsError(u'Windows version %s not supported yet.'
-                                       % win_version)
+                    raise WindowsError(u'Windows version {0!s} not supported yet.'.format(win_version))
                 base_dir_cand.extend([[home] + sub_dir + [DIRNAME_WIN],
                                      [home] + sub_dir + [DIRNAME_WIN_FBCK]])
             else:
@@ -340,10 +339,10 @@ def get_base_dir(test_directory=None):
         base_dir = os.path.normpath(os.path.join(os.getcwd(), base_dir))
     # make sure this path is valid and that it contains user-config file
     if not os.path.isdir(base_dir):
-        raise RuntimeError("Directory '%s' does not exist." % base_dir)
+        raise RuntimeError("Directory '{0!s}' does not exist.".format(base_dir))
     # check if user-config.py is in base_dir
     if not exists(base_dir):
-        exc_text = "No user-config.py found in directory '%s'.\n" % base_dir
+        exc_text = "No user-config.py found in directory '{0!s}'.\n".format(base_dir)
         if __no_user_config:
             if __no_user_config != '2':
                 output(exc_text)
@@ -903,7 +902,7 @@ def _win32_extension_command(extension):
         key1 = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_name)
         _progID = winreg.EnumValue(key1, 0)[0]
         _key2 = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT,
-                                '%s\shell\open\command' % _progID)
+                                '{0!s}\shell\open\command'.format(_progID))
         _cmd = _winreg.QueryValueEx(_key2, None)[0]
         # See T102465 for issues relating to using this value.
         cmd = _cmd
@@ -980,11 +979,9 @@ for _filename in _fns:
                 with open(_filename, 'rb') as f:
                     exec(compile(f.read(), _filename, 'exec'), _uc)
             else:
-                warning("Skipped '%(fn)s': writeable by others."
-                        % {'fn': _filename})
+                warning("Skipped '{fn!s}': writeable by others.".format(**{'fn': _filename}))
         else:
-            warning("Skipped '%(fn)s': owned by someone else."
-                    % {'fn': _filename})
+            warning("Skipped '{fn!s}': owned by someone else.".format(**{'fn': _filename}))
 
 
 class _DifferentTypeError(UserWarning, TypeError):
@@ -1133,8 +1130,8 @@ if __name__ == "__main__":
                         if isinstance(_value, dict):
                             _value = '{ ...xxxxxxxx... }'
                         elif hasattr(_value, '__dict__'):
-                            _value = '%s( ...xxxxxxxx... )' % \
-                                     _value.__class__.__name__
+                            _value = '{0!s}( ...xxxxxxxx... )'.format( \
+                                     _value.__class__.__name__)
                         else:
                             _value = repr('xxxxxxxx')
                     else:

--- a/pywikibot/cosmetic_changes.py
+++ b/pywikibot/cosmetic_changes.py
@@ -163,7 +163,7 @@ def _format_isbn_match(match, strict=True):
         except stdnum_isbn.ValidationError as e:
             if strict:
                 raise
-            pywikibot.log('ISBN "%s" validation error: %s' % (isbn, e))
+            pywikibot.log('ISBN "{0!s}" validation error: {1!s}'.format(isbn, e))
             return isbn
 
         return stdnum_isbn.format(isbn)
@@ -173,7 +173,7 @@ def _format_isbn_match(match, strict=True):
         except scripts_isbn.InvalidIsbnException as e:
             if strict:
                 raise
-            pywikibot.log('ISBN "%s" validation error: %s' % (isbn, e))
+            pywikibot.log('ISBN "{0!s}" validation error: {1!s}'.format(isbn, e))
             return isbn
 
         isbn = scripts_isbn.getIsbn(isbn)
@@ -182,7 +182,7 @@ def _format_isbn_match(match, strict=True):
         except scripts_isbn.InvalidIsbnException as e:
             if strict:
                 raise
-            pywikibot.log('ISBN "%s" validation error: %s' % (isbn, e))
+            pywikibot.log('ISBN "{0!s}" validation error: {1!s}'.format(isbn, e))
         return isbn.code
 
 
@@ -287,8 +287,7 @@ class CosmeticChangesToolkit(object):
         Remove their language code prefix.
         """
         if not self.talkpage and pywikibot.calledModuleName() != 'interwiki':
-            interwikiR = re.compile(r'\[\[%s\s?:([^\[\]\n]*)\]\]'
-                                    % self.site.code)
+            interwikiR = re.compile(r'\[\[{0!s}\s?:([^\[\]\n]*)\]\]'.format(self.site.code))
             text = interwikiR.sub(r'[[\1]]', text)
         return text
 
@@ -370,8 +369,7 @@ class CosmeticChangesToolkit(object):
             # Removing the stars' issue
             starstext = textlib.removeDisabledParts(text)
             for star in starsList:
-                regex = re.compile(r'(\{\{(?:template:|)%s\|.*?\}\}[\s]*)'
-                                   % star, re.I)
+                regex = re.compile(r'(\{{\{{(?:template:|){0!s}\|.*?\}}\}}[\s]*)'.format(star), re.I)
                 found = regex.findall(starstext)
                 if found != []:
                     text = regex.sub('', text)
@@ -395,8 +393,8 @@ class CosmeticChangesToolkit(object):
             text = text.strip() + self.site.family.interwiki_text_separator
             allstars.sort()
             for element in allstars:
-                text += '%s%s' % (element.strip(), config.line_separator)
-                pywikibot.log(u'%s' % element.strip())
+                text += '{0!s}{1!s}'.format(element.strip(), config.line_separator)
+                pywikibot.log(u'{0!s}'.format(element.strip()))
         # Adding the interwiki
         if interwikiLinks:
             text = textlib.replaceLanguageLinks(text, interwikiLinks,
@@ -438,15 +436,14 @@ class CosmeticChangesToolkit(object):
             # lowerspaced and underscored namespaces
             for i in range(len(namespaces)):
                 item = namespaces[i].replace(' ', '[ _]')
-                item = u'[%s%s]' % (item[0], item[0].lower()) + item[1:]
+                item = u'[{0!s}{1!s}]'.format(item[0], item[0].lower()) + item[1:]
                 namespaces[i] = item
             namespaces.append(first_lower(thisNs))
             if thisNs and namespaces:
                 text = textlib.replaceExcept(
                     text,
-                    r'\[\[\s*(%s) *:(?P<nameAndLabel>.*?)\]\]'
-                    % '|'.join(namespaces),
-                    r'[[%s:\g<nameAndLabel>]]' % thisNs,
+                    r'\[\[\s*({0!s}) *:(?P<nameAndLabel>.*?)\]\]'.format('|'.join(namespaces)),
+                    r'[[{0!s}:\g<nameAndLabel>]]'.format(thisNs),
                     exceptions)
         return text
 
@@ -564,14 +561,14 @@ class CosmeticChangesToolkit(object):
 
                     if titleWithSection == label or \
                        first_lower(titleWithSection) == label:
-                        newLink = "[[%s]]" % label
+                        newLink = "[[{0!s}]]".format(label)
                     # Check if we can create a link with trailing characters
                     # instead of a pipelink
                     elif (len(titleWithSection) <= len(label) and
                           label[:len(titleWithSection)] == titleWithSection and
                           re.sub(trailR, '',
                                  label[len(titleWithSection):]) == ''):
-                        newLink = "[[%s]]%s" % (label[:len(titleWithSection)],
+                        newLink = "[[{0!s}]]{1!s}".format(label[:len(titleWithSection)],
                                                 label[len(titleWithSection):])
                     else:
                         # Try to capitalize the first letter of the title.
@@ -581,7 +578,7 @@ class CosmeticChangesToolkit(object):
                         # uppercase
                         if self.site.sitename == 'wikipedia:de':
                             titleWithSection = first_upper(titleWithSection)
-                        newLink = "[[%s|%s]]" % (titleWithSection, label)
+                        newLink = "[[{0!s}|{1!s}]]".format(titleWithSection, label)
                     # re-add spaces that were pulled out of the link.
                     # Examples:
                     #   text[[ title ]]text        -> text [[title]] text
@@ -676,7 +673,7 @@ class CosmeticChangesToolkit(object):
         return textlib.replaceExcept(
             text,
             r'(?m)^(={1,7}) *(?P<title>[^=]+?) *\1 *\r?\n',
-            r'\1 \g<title> \1%s' % config.LS,
+            r'\1 \g<title> \1{0!s}'.format(config.LS),
             ['comment', 'math', 'nowiki', 'pre'])
 
     def putSpacesInLists(self, text):
@@ -711,7 +708,7 @@ class CosmeticChangesToolkit(object):
                 if new is None:
                     new = ''
                 else:
-                    new = '{{%s}}' % new
+                    new = '{{{{{0!s}}}}}'.format(new)
 
                 text = textlib.replaceExcept(
                     text,
@@ -893,8 +890,7 @@ class CosmeticChangesToolkit(object):
         # This only works if there are only two items in digits dict
         old = digits[list(digits.keys())[0]]
         # not to let bot edits in latin content
-        exceptions.append(re.compile(u"[^%(fa)s] *?\"*? *?, *?[^%(fa)s]"
-                                     % {'fa': faChrs}))
+        exceptions.append(re.compile(u"[^{fa!s}] *?\"*? *?, *?[^{fa!s}]".format(**{'fa': faChrs})))
         text = textlib.replaceExcept(text, ',', '،', exceptions, site=self.site)
         if self.site.code == 'ckb':
             text = textlib.replaceExcept(text,

--- a/pywikibot/data/api.py
+++ b/pywikibot/data/api.py
@@ -303,8 +303,7 @@ class ParamInfo(Container):
         # action=tokens and actions=query&meta=tokens, and this will warn if
         # any new ones appear.
         if _reused_module_names > set(['tokens']):
-            warn('Unexpected overlap between action and query submodules: %s'
-                 % (_reused_module_names - set(['tokens'])), UserWarning)
+            warn('Unexpected overlap between action and query submodules: {0!s}'.format((_reused_module_names - set(['tokens']))), UserWarning)
 
     def _emulate_pageset(self):
         """Emulate the pageset module, which existed in MW 1.15-1.24."""
@@ -470,7 +469,7 @@ class ParamInfo(Container):
                 path_prefix = 'query+'
 
             for submodule in submodules:
-                mod_begin_string = '* %s=%s' % (mod_type, submodule)
+                mod_begin_string = '* {0!s}={1!s}'.format(mod_type, submodule)
                 start = help_text.find(mod_begin_string)
                 assert(start)
                 start += len(mod_begin_string)
@@ -604,8 +603,7 @@ class ParamInfo(Container):
         if MediaWikiVersion(self.site.version()) < MediaWikiVersion("1.12"):
             # When the help is parsed, all paraminfo should already be loaded
             # and the caller is responsible for detecting missing modules.
-            pywikibot.log('ParamInfo did not detect modules: %s'
-                          % modules, _logger=_logger)
+            pywikibot.log('ParamInfo did not detect modules: {0!s}'.format(modules), _logger=_logger)
             return
 
         # If something went wrong in a batch it can add each module to the
@@ -885,10 +883,10 @@ class ParamInfo(Container):
         try:
             module = self[module]
         except KeyError:
-            raise ValueError("paraminfo for '%s' not loaded" % module)
+            raise ValueError("paraminfo for '{0!s}' not loaded".format(module))
 
         if 'parameters' not in module:
-            pywikibot.warning("module '%s' has no parameters" % module)
+            pywikibot.warning("module '{0!s}' has no parameters".format(module))
             return
 
         params = module['parameters']
@@ -1448,8 +1446,7 @@ class Request(MutableMapping):
             assert('name' in self.site._userinfo)
 
             if ip.is_IP(self.site._userinfo['name']):
-                raise Error(u"API write action attempted as IP %r"
-                            % self.site._userinfo['name'])
+                raise Error(u"API write action attempted as IP {0!r}".format(self.site._userinfo['name']))
 
             if not self.site.user():
                 pywikibot.warning(
@@ -1700,8 +1697,7 @@ class Request(MutableMapping):
         if "format" not in self._params:
             self._params["format"] = ["json"]
         elif self._params['format'] != ["json"]:
-            raise TypeError("Query format '%s' cannot be parsed."
-                            % self._params['format'])
+            raise TypeError("Query format '{0!s}' cannot be parsed.".format(self._params['format']))
 
         self.__defaulted = True
 
@@ -1776,7 +1772,7 @@ class Request(MutableMapping):
 
     def __repr__(self):
         """Return internal representation."""
-        return '%s.%s<%s->%r>' % (self.__class__.__module__, self.__class__.__name__,
+        return '{0!s}.{1!s}<{2!s}->{3!r}>'.format(self.__class__.__module__, self.__class__.__name__,
                                   self.site, str(self))
 
     def _simulate(self, action):
@@ -1881,7 +1877,7 @@ class Request(MutableMapping):
                 for single_warning in text.splitlines():
                     if (not callable(self._warning_handler) or
                             not self._warning_handler(mod, single_warning)):
-                        pywikibot.warning(u"API warning (%s): %s" % (mod, single_warning))
+                        pywikibot.warning(u"API warning ({0!s}): {1!s}".format(mod, single_warning))
 
     def submit(self):
         """
@@ -1971,12 +1967,12 @@ class Request(MutableMapping):
             except Exception:
                 # for any other error on the http request, wait and retry
                 pywikibot.error(traceback.format_exc())
-                pywikibot.log(u"%s, %s" % (uri, paramstring))
+                pywikibot.log(u"{0!s}, {1!s}".format(uri, paramstring))
                 self.wait()
                 continue
             if not isinstance(rawdata, unicode):
                 rawdata = rawdata.decode(self.site.encoding())
-            pywikibot.debug((u"API response received from %s:\n" % self.site) +
+            pywikibot.debug((u"API response received from {0!s}:\n".format(self.site)) +
                             rawdata, _logger)
             if rawdata.startswith(u"unknown_action"):
                 raise APIError(rawdata[:14], rawdata[16:])
@@ -1986,8 +1982,7 @@ class Request(MutableMapping):
                 # if the result isn't valid JSON, there must be a server
                 # problem.  Wait a few seconds and try again
                 pywikibot.warning(
-                    "Non-JSON response received from server %s; the server may be down."
-                    % self.site)
+                    "Non-JSON response received from server {0!s}; the server may be down.".format(self.site))
                 # there might also be an overflow, so try a smaller limit
                 for param in self._params:
                     if param.endswith("limit"):
@@ -1995,8 +1990,7 @@ class Request(MutableMapping):
                         value = self._params[param][0]
                         try:
                             self._params[param] = [str(int(value) // 2)]
-                            pywikibot.output(u"Set %s = %s"
-                                             % (param, self._params[param]))
+                            pywikibot.output(u"Set {0!s} = {1!s}".format(param, self._params[param]))
                         except:
                             pass
                 self.wait()
@@ -2005,8 +1999,7 @@ class Request(MutableMapping):
                 result = {}
             if not isinstance(result, dict):
                 raise APIError("Unknown",
-                               "Unable to process query response of type %s."
-                               % type(result),
+                               "Unable to process query response of type {0!s}.".format(type(result)),
                                data=result)
 
             if self.action == 'query' and 'userinfo' in result.get('query', ()):
@@ -2036,7 +2029,7 @@ class Request(MutableMapping):
                     continue
                 assert key not in error
                 assert isinstance(result[key], basestring), \
-                    'Unexpected %s: %r' % (key, result[key])
+                    'Unexpected {0!s}: {1!r}'.format(key, result[key])
                 error[key] = result[key]
 
             if "*" in result["error"]:
@@ -2084,7 +2077,7 @@ class Request(MutableMapping):
                 return {'help': {'mime': 'text/plain',
                                  'help': result['error']['help']}}
 
-            pywikibot.warning('API error %s: %s' % (code, info))
+            pywikibot.warning('API error {0!s}: {1!s}'.format(code, info))
 
             if code.startswith(u'internal_api_error_'):
                 class_name = code[len(u'internal_api_error_'):]
@@ -2097,8 +2090,7 @@ class Request(MutableMapping):
                                        'ReadOnlyError'  # T61227
                                        ]
 
-                pywikibot.error("Detected MediaWiki API exception %s%s"
-                                % (e,
+                pywikibot.error("Detected MediaWiki API exception {0!s}{1!s}".format(e,
                                    "; retrying" if retry else "; raising"))
                 # Due to bug T66958, Page's repr may return non ASCII bytes
                 # Get as bytes in PY2 and decode with the console encoding as
@@ -2163,8 +2155,7 @@ class Request(MutableMapping):
                             ', '.join('{0}: {1}'.format(*e)
                                       for e in user_tokens.items())))
             if 'mwoauth-invalid-authorization' in code:
-                raise NoUsername('Failed OAuth authentication for %s: %s'
-                                 % (self.site, info))
+                raise NoUsername('Failed OAuth authentication for {0!s}: {1!s}'.format(self.site, info))
             # raise error
             try:
                 # Due to bug T66958, Page's repr may return non ASCII bytes
@@ -2173,10 +2164,8 @@ class Request(MutableMapping):
                 param_repr = str(self._params)
                 if PY2:
                     param_repr = param_repr.decode(config.console_encoding)
-                pywikibot.log(u"API Error: query=\n%s"
-                              % pprint.pformat(param_repr))
-                pywikibot.log(u"           response=\n%s"
-                              % result)
+                pywikibot.log(u"API Error: query=\n{0!s}".format(pprint.pformat(param_repr)))
+                pywikibot.log(u"           response=\n{0!s}".format(result))
 
                 raise APIError(**result['error'])
             except TypeError:
@@ -2187,8 +2176,7 @@ class Request(MutableMapping):
         self.max_retries -= 1
         if self.max_retries < 0:
             raise TimeoutError("Maximum retries attempted without success.")
-        pywikibot.warning(u"Waiting %s seconds before retrying."
-                          % self.retry_wait)
+        pywikibot.warning(u"Waiting {0!s} seconds before retrying.".format(self.retry_wait))
         time.sleep(self.retry_wait)
         # double the next wait, but do not exceed 120 seconds
         self.retry_wait = min(120, self.retry_wait * 2)
@@ -2269,7 +2257,7 @@ class CachedRequest(Request):
             # The returned value cant be encoded to anything other than
             # ascii otherwise it creates an exception when _create_file_name()
             # tries to encode it as utf-8.
-            user_key = u'User(User:%s)' % self.site._userinfo['name']
+            user_key = u'User(User:{0!s})'.format(self.site._userinfo['name'])
         else:
             user_key = pywikibot.site.LoginStatus(
                 max(login_status, pywikibot.site.LoginStatus.NOT_LOGGED_IN))
@@ -2310,15 +2298,14 @@ class CachedRequest(Request):
             if self._expired(self._cachetime):
                 self._data = None
                 return False
-            pywikibot.debug(u"%s: cache hit (%s) for API request: %s"
-                            % (self.__class__.__name__, filename, uniquedescr),
+            pywikibot.debug(u"{0!s}: cache hit ({1!s}) for API request: {2!s}".format(self.__class__.__name__, filename, uniquedescr),
                             _logger)
             return True
         except IOError as e:
             # file not found
             return False
         except Exception as e:
-            pywikibot.output("Could not load cache: %r" % e)
+            pywikibot.output("Could not load cache: {0!r}".format(e))
             return False
 
     def _write_cache(self, data):
@@ -2408,8 +2395,7 @@ class APIGenerator(_RequestWrapper):
         """
         self.query_increment = int(value)
         self.request[self.limit_name] = self.query_increment
-        pywikibot.debug(u"%s: Set query_increment to %i."
-                        % (self.__class__.__name__, self.query_increment),
+        pywikibot.debug(u"{0!s}: Set query_increment to {1:d}.".format(self.__class__.__name__, self.query_increment),
                         _logger)
 
     def set_maximum_items(self, value):
@@ -2426,10 +2412,8 @@ class APIGenerator(_RequestWrapper):
         self.limit = int(value)
         if self.limit < self.query_increment:
             self.request[self.limit_name] = self.limit
-            pywikibot.debug(u"%s: Set request item limit to %i"
-                            % (self.__class__.__name__, self.limit), _logger)
-        pywikibot.debug(u"%s: Set limit (maximum_items) to %i."
-                        % (self.__class__.__name__, self.limit), _logger)
+            pywikibot.debug(u"{0!s}: Set request item limit to {1:d}".format(self.__class__.__name__, self.limit), _logger)
+        pywikibot.debug(u"{0!s}: Set limit (maximum_items) to {1:d}.".format(self.__class__.__name__, self.limit), _logger)
 
     def __iter__(self):
         """
@@ -2441,12 +2425,12 @@ class APIGenerator(_RequestWrapper):
         n = 0
         while True:
             self.request[self.continue_name] = offset
-            pywikibot.debug(u"%s: Request: %s" % (self.__class__.__name__,
+            pywikibot.debug(u"{0!s}: Request: {1!s}".format(self.__class__.__name__,
                                                   self.request), _logger)
             data = self.request.submit()
 
             n_items = len(data[self.data_name])
-            pywikibot.debug(u"%s: Retrieved %d items" % (
+            pywikibot.debug(u"{0!s}: Retrieved {1:d} items".format(
                 self.__class__.__name__, n_items), _logger)
             if n_items > 0:
                 for item in data[self.data_name]:
@@ -2495,8 +2479,7 @@ class QueryGenerator(_RequestWrapper):
             kwargs = self._clean_kwargs(kwargs)  # hasn't been called yet
         parameters = kwargs['parameters']
         if 'action' in parameters and parameters['action'] != 'query':
-            raise Error("%s: 'action' must be 'query', not %s"
-                        % (self.__class__.__name__, kwargs["action"]))
+            raise Error("{0!s}: 'action' must be 'query', not {1!s}".format(self.__class__.__name__, kwargs["action"]))
         else:
             parameters['action'] = 'query'
         # make sure request type is valid, and get limit key if any
@@ -2505,8 +2488,7 @@ class QueryGenerator(_RequestWrapper):
                 self.modules = parameters[modtype].split('|')
                 break
         else:
-            raise Error("%s: No query module name found in arguments."
-                        % self.__class__.__name__)
+            raise Error("{0!s}: No query module name found in arguments.".format(self.__class__.__name__))
 
         parameters['indexpageids'] = True  # always ask for list of pageids
         if MediaWikiVersion(self.site.version()) < MediaWikiVersion('1.21'):
@@ -2594,8 +2576,7 @@ class QueryGenerator(_RequestWrapper):
             self.query_limit = limit
         else:
             self.query_limit = min(self.api_limit, limit)
-        pywikibot.debug(u"%s: Set query_limit to %i."
-                        % (self.__class__.__name__, self.query_limit),
+        pywikibot.debug(u"{0!s}: Set query_limit to {1:d}.".format(self.__class__.__name__, self.query_limit),
                         _logger)
 
     def set_maximum_items(self, value):
@@ -2620,8 +2601,7 @@ class QueryGenerator(_RequestWrapper):
             self.api_limit = int(param["highmax"])
         else:
             self.api_limit = int(param["max"])
-        pywikibot.debug(u"%s: Set query_limit to %i."
-                        % (self.__class__.__name__,
+        pywikibot.debug(u"{0!s}: Set query_limit to {1:d}.".format(self.__class__.__name__,
                            self.api_limit),
                         _logger)
 
@@ -2666,8 +2646,7 @@ class QueryGenerator(_RequestWrapper):
         if all(key not in self.data[self.continue_name]
                for key in self.continuekey):
             pywikibot.log(
-                u"Missing '%s' key(s) in ['%s'] value."
-                % (self.continuekey, self.continue_name))
+                u"Missing '{0!s}' key(s) in ['{1!s}'] value.".format(self.continuekey, self.continue_name))
             return True
         for query_continue_pair in self.data['query-continue'].values():
             self._add_continues(query_continue_pair)
@@ -2728,8 +2707,7 @@ class QueryGenerator(_RequestWrapper):
                            self.limit, new_limit, count),
                         _logger)
                     pywikibot.debug(
-                        u"%s: %s: %s"
-                        % (self.__class__.__name__,
+                        u"{0!s}: {1!s}: {2!s}".format(self.__class__.__name__,
                            self.prefix + "limit",
                            self.request[self.prefix + "limit"]),
                         _logger)
@@ -2737,15 +2715,13 @@ class QueryGenerator(_RequestWrapper):
                 self.data = self.request.submit()
             if not self.data or not isinstance(self.data, dict):
                 pywikibot.debug(
-                    u"%s: stopped iteration because no dict retrieved from api."
-                    % self.__class__.__name__,
+                    u"{0!s}: stopped iteration because no dict retrieved from api.".format(self.__class__.__name__),
                     _logger)
                 return
             if 'query' in self.data and self.resultkey in self.data["query"]:
                 resultdata = self.data["query"][self.resultkey]
                 if isinstance(resultdata, dict):
-                    pywikibot.debug(u"%s received %s; limit=%s"
-                                    % (self.__class__.__name__,
+                    pywikibot.debug(u"{0!s} received {1!s}; limit={2!s}".format(self.__class__.__name__,
                                        list(resultdata.keys()),
                                        self.limit),
                                     _logger)
@@ -2760,8 +2736,7 @@ class QueryGenerator(_RequestWrapper):
                         resultdata = [resultdata[k]
                                       for k in sorted(resultdata.keys())]
                 else:
-                    pywikibot.debug(u"%s received %s; limit=%s"
-                                    % (self.__class__.__name__,
+                    pywikibot.debug(u"{0!s} received {1!s}; limit={2!s}".format(self.__class__.__name__,
                                        resultdata,
                                        self.limit),
                                     _logger)
@@ -2790,8 +2765,8 @@ class QueryGenerator(_RequestWrapper):
                 previous_result_had_data = True
             else:
                 if 'query' not in self.data:
-                    pywikibot.log("%s: 'query' not found in api response." %
-                                  self.__class__.__name__)
+                    pywikibot.log("{0!s}: 'query' not found in api response.".format(
+                                  self.__class__.__name__))
                     pywikibot.log(unicode(self.data))
                 # if (query-)continue is present, self.resultkey might not have
                 # been fetched yet
@@ -3002,8 +2977,7 @@ class LoginManager(login.LoginManager):
         if hasattr(self, '_waituntil'):
             if datetime.datetime.now() < self._waituntil:
                 diff = self._waituntil - datetime.datetime.now()
-                pywikibot.warning(u"Too many tries, waiting %s seconds before retrying."
-                                  % diff.seconds)
+                pywikibot.warning(u"Too many tries, waiting {0!s} seconds before retrying.".format(diff.seconds))
                 time.sleep(diff.seconds)
 
         # base login request
@@ -3026,8 +3000,7 @@ class LoginManager(login.LoginManager):
                 prefix = login_result['login']['cookieprefix']
                 cookies = []
                 for key in ('Token', 'UserID', 'UserName'):
-                    cookies.append("%s%s=%s"
-                                   % (prefix, key,
+                    cookies.append("{0!s}{1!s}={2!s}".format(prefix, key,
                                       login_result['login']['lg' + key.lower()]))
                 self.username = login_result['login']['lgusername']
                 return "\n".join(cookies)
@@ -3121,7 +3094,7 @@ def update_page(page, pagedict, props=None):
         page._pageid = 0    # Non-existent page
     else:
         raise AssertionError(
-            "Page %s has neither 'pageid' nor 'missing' attribute" % pagedict['title'])
+            "Page {0!s} has neither 'pageid' nor 'missing' attribute".format(pagedict['title']))
     page._contentmodel = pagedict.get('contentmodel')  # can be None
     if (page._contentmodel and
             page._contentmodel == 'proofread-page' and

--- a/pywikibot/data/mysql.py
+++ b/pywikibot/data/mysql.py
@@ -62,7 +62,7 @@ def mysql_query(query, params=(), dbname=None, encoding='utf-8', verbose=None):
 
     cursor = conn.cursor()
     if verbose:
-        pywikibot.output('Executing query:\n%s' % query)
+        pywikibot.output('Executing query:\n{0!s}'.format(query))
     query = query.encode(encoding)
     params = tuple(p.encode(encoding) for p in params)
 

--- a/pywikibot/data/sparql.py
+++ b/pywikibot/data/sparql.py
@@ -66,7 +66,7 @@ class SparqlQuery(object):
                 for var in qvars:
                     if full_data:
                         if row[var]['type'] not in VALUE_TYPES:
-                            raise ValueError('Unknown type: %s' % row[var]['type'])
+                            raise ValueError('Unknown type: {0!s}'.format(row[var]['type']))
                         valtype = VALUE_TYPES[row[var]['type']]
                         values[var] = valtype(row[var], entity_url=self.entity_url)
                     else:
@@ -83,7 +83,7 @@ class SparqlQuery(object):
         @param query: Query text
         @type query: string
         """
-        url = '%s?query=%s' % (self.endpoint, quote(query))
+        url = '{0!s}?query={1!s}'.format(self.endpoint, quote(query))
         self.last_response = http.fetch(url, headers=headers)
         if not self.last_response.content:
             return None

--- a/pywikibot/data/wikidataquery.py
+++ b/pywikibot/data/wikidataquery.py
@@ -103,20 +103,20 @@ class QuerySet(object):
         """
         def bracketIfQuerySet(q):
             if isinstance(q, QuerySet) and q.joiner != self.joiner:
-                return "(%s)" % q
+                return "({0!s})".format(q)
             else:
                 return str(q)
 
         s = bracketIfQuerySet(self.qs[0])
 
         for q in self.qs[1:]:
-            s += " %s %s" % (self.joiner, bracketIfQuerySet(q))
+            s += " {0!s} {1!s}".format(self.joiner, bracketIfQuerySet(q))
 
         return s
 
     def __repr__(self):
         """Return a string representation."""
-        return u"QuerySet(%s)" % self
+        return u"QuerySet({0!s})".format(self)
 
 
 class Query(object):
@@ -241,7 +241,7 @@ class Query(object):
 
     def __repr__(self):
         """Return a string representation."""
-        return u"Query(%s)" % self
+        return u"Query({0!s})".format(self)
 
 
 class HasClaim(Query):
@@ -285,9 +285,9 @@ class HasClaim(Query):
     def __str__(self):
         """Return the query string for the API."""
         if isinstance(self.items, list):
-            return "%s[%s%s]" % (self.queryType, self.prop, self.formatItems())
+            return "{0!s}[{1!s}{2!s}]".format(self.queryType, self.prop, self.formatItems())
         elif isinstance(self.items, Query):
-            return "%s[%s:(%s)]" % (self.queryType, self.prop, self.items)
+            return "{0!s}[{1!s}:({2!s})]".format(self.queryType, self.prop, self.items)
 
 
 class NoClaim(HasClaim):
@@ -305,7 +305,7 @@ class StringClaim(HasClaim):
 
     def formatItem(self, x):
         """Add quotes around string."""
-        return '"%s"' % x
+        return '"{0!s}"'.format(x)
 
     def validate(self):
         """Validate that the items are strings."""
@@ -354,7 +354,7 @@ class Tree(Query):
 
     def __str__(self):
         """Return the query string for the API."""
-        return "%s[%s][%s][%s]" % (self.queryType, self.formatList(self.item),
+        return "{0!s}[{1!s}][{2!s}][{3!s}]".format(self.queryType, self.formatList(self.item),
                                    self.formatList(self.forward),
                                    self.formatList(self.reverse))
 
@@ -378,7 +378,7 @@ class Around(Query):
 
     def __str__(self):
         """Return the query string for the API."""
-        return "%s[%s,%s,%s,%s]" % (self.queryType, self.prop,
+        return "{0!s}[{1!s},{2!s},{3!s},{4!s}]".format(self.queryType, self.prop,
                                     self.lt, self.lg, self.rad)
 
 
@@ -414,7 +414,7 @@ class Between(Query):
         # if you don't have an end, you don't put in the comma
         end = ',' + self.end.toTimestr() if self.end else ''
 
-        return "%s[%s,%s%s]" % (self.queryType, self.prop, begin, end)
+        return "{0!s}[{1!s},{2!s}{3!s}]".format(self.queryType, self.prop, begin, end)
 
 
 class Link(Query):
@@ -438,7 +438,7 @@ class Link(Query):
 
     def __str__(self):
         """Return the query string for the API."""
-        return "%s[%s]" % (self.queryType, self.formatList(self.link))
+        return "{0!s}[{1!s}]".format(self.queryType, self.formatList(self.link))
 
 
 class NoLink(Link):
@@ -466,8 +466,7 @@ def fromClaim(claim):
     if claim.type in ('string', 'url', 'math', 'external-id'):
         return StringClaim(claim.getID(numeric=True), claim.getTarget())
     else:
-        raise TypeError("Cannot construct a query from a claim of type %s"
-                        % claim.type)
+        raise TypeError("Cannot construct a query from a claim of type {0!s}".format(claim.type))
 
 
 class WikidataQuery(object):
@@ -499,7 +498,7 @@ class WikidataQuery(object):
 
     def getUrl(self, queryStr):
         """Get the URL given the query string."""
-        return "%s/api?%s" % (self.host, queryStr)
+        return "{0!s}/api?{1!s}".format(self.host, queryStr)
 
     def getQueryString(self, q, labels=None, props=None):
         """
@@ -511,13 +510,13 @@ class WikidataQuery(object):
             labels = []
         if props is None:
             props = []
-        qStr = "q=%s" % quote(str(q))
+        qStr = "q={0!s}".format(quote(str(q)))
 
         if labels:
-            qStr += "&labels=%s" % ','.join(labels)
+            qStr += "&labels={0!s}".format(','.join(labels))
 
         if props:
-            qStr += "&props=%s" % ','.join(props)
+            qStr += "&props={0!s}".format(','.join(props))
 
         return qStr
 
@@ -550,8 +549,7 @@ class WikidataQuery(object):
                     try:
                         data = pickle.load(f)
                     except pickle.UnpicklingError:
-                        pywikibot.warning(u"Couldn't read cached data from %s"
-                                          % cacheFile)
+                        pywikibot.warning(u"Couldn't read cached data from {0!s}".format(cacheFile))
                         data = None
 
                 return data
@@ -582,7 +580,7 @@ class WikidataQuery(object):
             try:
                 pickle.dump(data, f, protocol=config.pickle_protocol)
             except IOError:
-                pywikibot.warning(u"Failed to write cache file %s" % cacheFile)
+                pywikibot.warning(u"Failed to write cache file {0!s}".format(cacheFile))
 
     def getDataFromHost(self, queryStr):
         """
@@ -595,23 +593,21 @@ class WikidataQuery(object):
         try:
             resp = http.fetch(url)
         except:
-            pywikibot.warning(u"Failed to retrieve %s" % url)
+            pywikibot.warning(u"Failed to retrieve {0!s}".format(url))
             raise
 
         data = resp.content
         if not data:
-            pywikibot.warning('No data received for %s' % url)
-            raise pywikibot.ServerError('No data received for %s' % url)
+            pywikibot.warning('No data received for {0!s}'.format(url))
+            raise pywikibot.ServerError('No data received for {0!s}'.format(url))
 
         try:
             data = json.loads(data)
         except ValueError:
             pywikibot.warning(
-                'Data received for %s but no JSON could be decoded: %r'
-                % (url, data))
+                'Data received for {0!s} but no JSON could be decoded: {1!r}'.format(url, data))
             raise pywikibot.ServerError(
-                'Data received for %s but no JSON could be decoded: %r'
-                % (url, data))
+                'Data received for {0!s} but no JSON could be decoded: {1!r}'.format(url, data))
 
         return data
 

--- a/pywikibot/data/wikistats.py
+++ b/pywikibot/data/wikistats.py
@@ -107,7 +107,7 @@ class WikiStats(object):
         URL = self.url + '/api.php?action=dump&table=%s&format=%s'
 
         if table not in self.ALL_KEYS:
-            pywikibot.warning('WikiStats unknown table %s' % table)
+            pywikibot.warning('WikiStats unknown table {0!s}'.format(table))
 
         if table in self.FAMILY_MAPPING:
             table = self.FAMILY_MAPPING[table]

--- a/pywikibot/date.py
+++ b/pywikibot/date.py
@@ -240,7 +240,7 @@ def dh_constVal(value, ind, match):
         if value == ind:
             return match
         else:
-            raise ValueError("unknown value %d" % value)
+            raise ValueError("unknown value {0:d}".format(value))
 
 
 def alwaysTrue(x):
@@ -314,7 +314,7 @@ _romanNumbers = ['-', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX',
 def intToRomanNum(i):
     """Convert integer to roman numeral."""
     if i >= len(_romanNumbers):
-        raise IndexError(u'Roman value %i is not defined' % i)
+        raise IndexError(u'Roman value {0:d} is not defined'.format(i))
     return _romanNumbers[i]
 
 
@@ -353,7 +353,7 @@ _digitDecoders = {
 
 # Allows to search for '(%%)|(%d)|(%R)|...", and allows one digit 1-9 to set
 # the size of zero-padding for numbers
-_reParameters = re.compile(u'|'.join(u'(%%[1-9]?%s)' % s
+_reParameters = re.compile(u'|'.join(u'(%[1-9]?{0!s})'.format(s)
                                      for s in _digitDecoders))
 
 # A map of   sitecode+pattern  to  (re matching object and corresponding
@@ -394,12 +394,12 @@ def escapePattern2(pattern):
                 else:
                     if len(s) == 3:
                         # enforce mandatory field size
-                        newPattern += u'([%s]{%s})' % (dec[0], s[1])
+                        newPattern += u'([{0!s}]{{{1!s}}})'.format(dec[0], s[1])
                         # add the number of required digits as the last (4th)
                         # part of the tuple
                         dec += (int(s[1]),)
                     else:
-                        newPattern += u'([%s]+)' % dec[0]
+                        newPattern += u'([{0!s}]+)'.format(dec[0])
 
                     decoders.append(dec)
                     # All encoders produce a string
@@ -466,7 +466,7 @@ def dh(value, pattern, encf, decf, filter=None):
         # This will be called from outside as well as recursivelly to verify
         # parsed value
         if filter and not filter(value):
-            raise ValueError("value %i is not allowed" % value)
+            raise ValueError("value {0:d} is not allowed".format(value))
 
         params = encf(value)
 
@@ -476,8 +476,7 @@ def dh(value, pattern, encf, decf, filter=None):
         if type(params) in _listTypes:
             if len(params) != len(decoders):
                 raise AssertionError(
-                    "parameter count (%d) does not match decoder count (%d)"
-                    % (len(params), len(decoders)))
+                    "parameter count ({0:d}) does not match decoder count ({1:d})".format(len(params), len(decoders)))
             # convert integer parameters into their textual representation
             params = [MakeParameter(decoders[i], params[i])
                       for i in range(len(params))]
@@ -485,8 +484,7 @@ def dh(value, pattern, encf, decf, filter=None):
         else:
             if 1 != len(decoders):
                 raise AssertionError(
-                    "A single parameter does not match %d decoders."
-                    % len(decoders))
+                    "A single parameter does not match {0:d} decoders.".format(len(decoders)))
             # convert integer parameter into its textual representation
             return strPattern % MakeParameter(decoders[0], params)
 
@@ -1970,16 +1968,16 @@ def addFmt1(lang, isMnthOfYear, patterns):
 
     """
     if len(patterns) != 12:
-        raise AssertionError(u'pattern %s does not have 12 elements' % lang)
+        raise AssertionError(u'pattern {0!s} does not have 12 elements'.format(lang))
 
     for i in range(12):
         if patterns[i] is not None:
             if isMnthOfYear:
                 formats[yrMnthFmts[i]][lang] = eval(
-                    u'lambda v: dh_mnthOfYear(v, u"%s")' % patterns[i])
+                    u'lambda v: dh_mnthOfYear(v, u"{0!s}")'.format(patterns[i]))
             else:
                 formats[dayMnthFmts[i]][lang] = eval(
-                    u'lambda v: dh_dayOfMnth(v, u"%s")' % patterns[i])
+                    u'lambda v: dh_dayOfMnth(v, u"{0!s}")'.format(patterns[i]))
 
 
 def addFmt2(lang, isMnthOfYear, pattern, makeUpperCase=None):
@@ -2128,12 +2126,12 @@ addFmt2('ml', False, u"%s %%d")
 addFmt2('ms', False, u"%%d %s", True)
 addFmt2('nap', False, u"%%d 'e %s", False)
 addFmt2('nds', False, u"%%d. %s", True)
-addFmt1('nl', False, [u"%%d %s" % v
+addFmt1('nl', False, [u"%d {0!s}".format(v)
                       for v in [u"januari", u"februari", u"maart", u"april",
                                 u"mei", u"juni", u"juli", u"augustus",
                                 u"september", u"oktober", u"november",
                                 u"december"]])
-addFmt1('nn', False, [u"%%d. %s" % v
+addFmt1('nn', False, [u"%d. {0!s}".format(v)
                       for v in [u"januar", u"februar", u"mars", u"april",
                                 u"mai", u"juni", u"juli", u"august",
                                 u"september", u"oktober", u"november",
@@ -2246,7 +2244,7 @@ addFmt1('fr', True, [u"Janvier %d", u"Février %d", u"Mars %d", u"Avril %d",
                      u"Décembre %d"])
 addFmt2('he', True, u"%s %%d", True)
 addFmt2('it', True, u"Attualità/Anno %%d - %s", True)
-addFmt1('ja', True, [u"「最近の出来事」%%d年%d月" % mm for mm in range(1, 13)])
+addFmt1('ja', True, [u"「最近の出来事」%d年{0:d}月".format(mm) for mm in range(1, 13)])
 addFmt2('ka', True, u"%s, %%d")
 addFmt1('ko', True, [u"%d년 1월", u"%d년 2월", u"%d년 3월", u"%d년 4월",
                      u"%d년 5월", u"%d년 6월", u"%d년 7월", u"%d년 8월",

--- a/pywikibot/diff.py
+++ b/pywikibot/diff.py
@@ -73,8 +73,8 @@ class Hunk(object):
         self.b_rng = (first[3], last[4])
 
         self.header = self.get_header()
-        self.diff_plain_text = u'%s\n%s' % (self.header, self.diff_plain_text)
-        self.diff_text = u'%s' % self.diff_text
+        self.diff_plain_text = u'{0!s}\n{1!s}'.format(self.header, self.diff_plain_text)
+        self.diff_text = u'{0!s}'.format(self.diff_text)
 
         self.reviewed = self.PENDING
 
@@ -185,8 +185,7 @@ class Hunk(object):
     def __repr__(self):
         """Return a reconstructable representation."""
         # TODO
-        return '%s(a, b, %s)' \
-               % (self.__class__.__name__, self.group)
+        return '{0!s}(a, b, {1!s})'.format(self.__class__.__name__, self.group)
 
 
 class _SuperHunk(Sequence):
@@ -507,7 +506,7 @@ class PatchManager(object):
                         '{0} -> {1}'.format(answer, help_msg[answer])
                         for answer in answers)))
             else:
-                assert False, '%s is not a valid option' % choice
+                assert False, '{0!s} is not a valid option'.format(choice)
 
     def apply(self):
         """Apply changes. If there are undecided changes, ask to review."""

--- a/pywikibot/editor.py
+++ b/pywikibot/editor.py
@@ -46,26 +46,26 @@ class TextEditor(object):
         # Linux editors. We use startswith() because some users might use
         # parameters.
         if config.editor.startswith('kate'):
-            command = ['-l', '%i' % (line + 1), '-c', '%i' % (column + 1)]
+            command = ['-l', '{0:d}'.format((line + 1)), '-c', '{0:d}'.format((column + 1))]
         elif config.editor.startswith('gedit'):
-            command = ['+%i' % (line + 1)]  # seems not to support columns
+            command = ['+{0:d}'.format((line + 1))]  # seems not to support columns
         elif config.editor.startswith('emacs'):
-            command = ['+%i' % (line + 1)]  # seems not to support columns
+            command = ['+{0:d}'.format((line + 1))]  # seems not to support columns
         elif config.editor.startswith('jedit'):
-            command = ['+line:%i' % (line + 1)]  # seems not to support columns
+            command = ['+line:{0:d}'.format((line + 1))]  # seems not to support columns
         elif config.editor.startswith('vim'):
-            command = ['+%i' % (line + 1)]  # seems not to support columns
+            command = ['+{0:d}'.format((line + 1))]  # seems not to support columns
         elif config.editor.startswith('nano'):
-            command = ['+%i,%i' % (line + 1, column + 1)]
+            command = ['+{0:d},{1:d}'.format(line + 1, column + 1)]
         # Windows editors
         elif config.editor.lower().endswith('notepad++.exe'):
-            command = ['-n%i' % (line + 1)]  # seems not to support columns
+            command = ['-n{0:d}'.format((line + 1))]  # seems not to support columns
         else:
             command = []
 
         # See T102465 for problems relating to using config.editor unparsed.
         command = [config.editor] + command + [file_name]
-        pywikibot.log(u'Running editor: %s' % TextEditor._concat(command))
+        pywikibot.log(u'Running editor: {0!s}'.format(TextEditor._concat(command)))
         return command
 
     @staticmethod
@@ -96,7 +96,7 @@ class TextEditor(object):
         """
         if config.editor:
             handle, tempFilename = tempfile.mkstemp()
-            tempFilename = '%s.%s' % (tempFilename,
+            tempFilename = '{0!s}.{1!s}'.format(tempFilename,
                                       config.editor_filename_extension)
             try:
                 with codecs.open(tempFilename, 'w',

--- a/pywikibot/family.py
+++ b/pywikibot/family.py
@@ -902,7 +902,7 @@ class Family(object):
             fam = config.family
 
         assert all(x in NAME_CHARACTERS for x in fam), \
-            'Name of family %s must be ASCII characters and digits' % fam
+            'Name of family {0!s} must be ASCII characters and digits'.format(fam)
 
         if fam in Family._families:
             return Family._families[fam]
@@ -923,15 +923,14 @@ class Family(object):
                 warnings.simplefilter("ignore", RuntimeWarning)
                 mod = imp.load_source(fam, config.family_files[fam])
         except (ImportError, KeyError):
-            raise UnknownFamily(u'Family %s does not exist' % fam)
+            raise UnknownFamily(u'Family {0!s} does not exist'.format(fam))
         cls = mod.Family()
         if cls.name != fam:
-            warn(u'Family name %s does not match family module name %s'
-                 % (cls.name, fam), FamilyMaintenanceWarning)
+            warn(u'Family name {0!s} does not match family module name {1!s}'.format(cls.name, fam), FamilyMaintenanceWarning)
         # Family 'name' and the 'langs' codes must be ascii, and the
         # codes must be lower-case due to the Site loading algorithm.
         if not all(x in NAME_CHARACTERS for x in cls.name):
-            warn(u'Family name %s contains non-ascii characters' % cls.name,
+            warn(u'Family name {0!s} contains non-ascii characters'.format(cls.name),
                  FamilyMaintenanceWarning)
         # FIXME: wikisource uses code '-' for www.wikisource.org
         if not all(all(x in CODE_CHARACTERS for x in code) and
@@ -971,8 +970,7 @@ class Family(object):
             return self.linktrails[fallback]
         else:
             raise KeyError(
-                "ERROR: linktrail in language %(language_code)s unknown"
-                % {'language_code': code})
+                "ERROR: linktrail in language {language_code!s} unknown".format(**{'language_code': code}))
 
     def _category_redirects(self, code, fallback='_default'):
         """Return list of category redirect templates."""
@@ -1026,8 +1024,7 @@ class Family(object):
             return self.disambiguationTemplates[fallback]
         else:
             raise KeyError(
-                "ERROR: title for disambig template in language %s unknown"
-                % code)
+                "ERROR: title for disambig template in language {0!s} unknown".format(code))
 
     # Methods
     def protocol(self, code):
@@ -1108,15 +1105,15 @@ class Family(object):
 
     def path(self, code):
         """Return path to index.php."""
-        return '%s/index.php' % self.scriptpath(code)
+        return '{0!s}/index.php'.format(self.scriptpath(code))
 
     def querypath(self, code):
         """Return path to query.php."""
-        return '%s/query.php' % self.scriptpath(code)
+        return '{0!s}/query.php'.format(self.scriptpath(code))
 
     def apipath(self, code):
         """Return path to api.php."""
-        return '%s/api.php' % self.scriptpath(code)
+        return '{0!s}/api.php'.format(self.scriptpath(code))
 
     @deprecated('APISite.article_path')
     def nicepath(self, code):
@@ -1130,12 +1127,12 @@ class Family(object):
     @deprecated_args(name='title')
     def get_address(self, code, title):
         """Return the path to title using index.php with redirects disabled."""
-        return '%s?title=%s&redirect=no' % (self.path(code), title)
+        return '{0!s}?title={1!s}&redirect=no'.format(self.path(code), title)
 
     @deprecated('APISite.nice_get_address(title)')
     def nice_get_address(self, code, title):
         """DEPRECATED: Return the nice path to title using index.php."""
-        return '%s%s' % (self.nicepath(code), title)
+        return '{0!s}{1!s}'.format(self.nicepath(code), title)
 
     def interface(self, code):
         """
@@ -1145,8 +1142,7 @@ class Family(object):
         """
         if code in self.interwiki_removals:
             if code in self.codes:
-                pywikibot.warn('Interwiki removal %s is in %s codes'
-                               % (code, self))
+                pywikibot.warn('Interwiki removal {0!s} is in {1!s} codes'.format(code, self))
             return 'RemovedSite'
 
         return config.site_interface
@@ -1230,7 +1226,7 @@ class Family(object):
 
     def dbName(self, code):
         """Return the name of the MySQL database."""
-        return '%s%s' % (code, self.name)
+        return '{0!s}{1!s}'.format(code, self.name)
 
     # Which version of MediaWiki is used?
     @deprecated('APISite.version()')
@@ -1321,7 +1317,7 @@ class Family(object):
         return self.name
 
     def __repr__(self):
-        return 'Family("%s")' % self.name
+        return 'Family("{0!s}")'.format(self.name)
 
     def shared_image_repository(self, code):
         """Return the shared image repository, if any."""
@@ -1453,7 +1449,7 @@ class SubdomainFamily(Family):
             codes = codes + self.test_codes
 
         self.langs = dict(
-            (code, '%s.%s' % (code, self.domain)) for code in codes)
+            (code, '{0!s}.{1!s}'.format(code, self.domain)) for code in codes)
 
         super(SubdomainFamily, self).__init__()
 
@@ -1463,8 +1459,7 @@ class SubdomainFamily(Family):
         if hasattr(self, 'languages_by_size'):
             return self.languages_by_size
         raise NotImplementedError(
-            'Family %s needs property "languages_by_size" or "codes"'
-            % self.name)
+            'Family {0!s} needs property "languages_by_size" or "codes"'.format(self.name))
 
     @property
     def domains(self):
@@ -1579,7 +1574,7 @@ class WikimediaFamily(Family):
             return 'wikimedia.org'
 
         raise NotImplementedError(
-            'Family %s needs to define property \'domain\'' % self.name)
+            'Family {0!s} needs to define property \'domain\''.format(self.name))
 
     @property
     def interwiki_removals(self):

--- a/pywikibot/i18n.py
+++ b/pywikibot/i18n.py
@@ -317,7 +317,7 @@ def _get_translation(lang, twtitle):
         return _cache[lang][twtitle]
     message_bundle = twtitle.split('-')[0]
     trans_text = None
-    filename = '%s/%s.json' % (message_bundle, lang)
+    filename = '{0!s}/{1!s}.json'.format(message_bundle, lang)
     try:
         trans_text = pkgutil.get_data(
             _messages_package_name, filename).decode('utf-8')
@@ -624,7 +624,7 @@ def twtranslate(code, twtitle, parameters=None, fallback=True,
             'No %s translation has been defined for TranslateWiki key'
             ' %r\nIt can happen due to lack of i18n submodule or files. '
             'Read https://mediawiki.org/wiki/PWB/i18n'
-            % ('English' if 'en' in langs else "'%s'" % lang,
+            % ('English' if 'en' in langs else "'{0!s}'".format(lang),
                twtitle))
     # send the language code back via the given list
     if code_needed:
@@ -728,8 +728,7 @@ def input(twtitle, parameters=None, password=False, fallback_prompt=None):
     if not messages_available():
         if not fallback_prompt:
             raise TranslationError(
-                'Unable to load messages package %s for bundle %s'
-                % (_messages_package_name, twtitle))
+                'Unable to load messages package {0!s} for bundle {1!s}'.format(_messages_package_name, twtitle))
         else:
             prompt = fallback_prompt
     else:

--- a/pywikibot/interwiki_graph.py
+++ b/pywikibot/interwiki_graph.py
@@ -57,9 +57,9 @@ class GraphSavingThread(threading.Thread):
             filename = config.datafilepath(
                 'interwiki-graphs/' + getFilename(self.originPage, format))
             if self.graph.write(filename, prog='dot', format=format):
-                pywikibot.output(u'Graph saved as %s' % filename)
+                pywikibot.output(u'Graph saved as {0!s}'.format(filename))
             else:
-                pywikibot.output(u'Graph could not be saved as %s' % filename)
+                pywikibot.output(u'Graph could not be saved as {0!s}'.format(filename))
 
 
 class Subject(object):
@@ -144,13 +144,13 @@ class GraphDrawer(object):
         @raises GraphImpossible: pydot is not installed
         """
         if isinstance(pydot, ImportError):
-            raise GraphImpossible('pydot is not installed: %s.' % pydot)
+            raise GraphImpossible('pydot is not installed: {0!s}.'.format(pydot))
         self.graph = None
         self.subject = subject
 
     def getLabel(self, page):
         """Get label for page."""
-        return '"%s:%s"' % (page.site.code, page.title())
+        return '"{0!s}:{1!s}"'.format(page.site.code, page.title())
 
     def _octagon_site_set(self):
         """Build a list of sites with more than one valid page."""
@@ -167,8 +167,7 @@ class GraphDrawer(object):
     def addNode(self, page):
         """Add a node for page."""
         node = pydot.Node(self.getLabel(page), shape='rectangle')
-        node.set_URL("\"http://%s%s\""
-                     % (page.site.hostname(),
+        node.set_URL("\"http://{0!s}{1!s}\"".format(page.site.hostname(),
                         page.site.get_address(page.title(asUrl=True))))
         node.set_style('filled')
         node.set_fillcolor('white')
@@ -206,8 +205,7 @@ class GraphDrawer(object):
             # https://sourceforge.net/p/pywikipediabot/bugs/401/
             elif self.graph.get_edge(sourceLabel, targetLabel):
                 pywikibot.output(
-                    u'BUG: Tried to create duplicate edge from %s to %s'
-                    % (refPage.title(asLink=True), page.title(asLink=True)))
+                    u'BUG: Tried to create duplicate edge from {0!s} to {1!s}'.format(refPage.title(asLink=True), page.title(asLink=True)))
                 # duplicate edges would be bad because then get_edge() would
                 # give a list of edges, not a single edge when we handle the
                 # opposite edge.
@@ -237,8 +235,7 @@ class GraphDrawer(object):
 
         For more info see U{http://meta.wikimedia.org/wiki/Interwiki_graphs}
         """
-        pywikibot.output(u'Preparing graph for %s'
-                         % self.subject.originPage.title())
+        pywikibot.output(u'Preparing graph for {0!s}'.format(self.subject.originPage.title()))
         # create empty graph
         self.graph = pydot.Dot()
         # self.graph.set('concentrate', 'true')
@@ -269,9 +266,9 @@ def getFilename(page, extension=None):
     @return: filename of <family>-<lang>-<page>.<ext>
     @rtype: str
     """
-    filename = '%s-%s-%s' % (page.site.family.name,
+    filename = '{0!s}-{1!s}-{2!s}'.format(page.site.family.name,
                              page.site.code,
                              page.title(as_filename=True))
     if extension:
-        filename += '.%s' % extension
+        filename += '.{0!s}'.format(extension)
     return filename

--- a/pywikibot/logentries.py
+++ b/pywikibot/logentries.py
@@ -34,7 +34,7 @@ class LogDict(dict):
         """Debug when the key is missing."""
         pywikibot.debug(u"API log entry received:\n" + repr(self),
                         _logger)
-        raise KeyError("Log entry (%s) has no '%s' key" % (self._type, key))
+        raise KeyError("Log entry ({0!s}) has no '{1!s}' key".format(self._type, key))
 
 
 class LogEntry(object):
@@ -51,8 +51,7 @@ class LogEntry(object):
         self.data = LogDict(apidata)
         self.site = site
         if self._expectedType is not None and self._expectedType != self.type():
-            raise Error("Wrong log type! Expecting %s, received %s instead."
-                        % (self._expectedType, self.type()))
+            raise Error("Wrong log type! Expecting {0!s}, received {1!s} instead.".format(self._expectedType, self.type()))
         self.data._type = self.type()
 
     def __hash__(self):

--- a/pywikibot/logging.py
+++ b/pywikibot/logging.py
@@ -197,7 +197,7 @@ def exception(msg=None, decoder=None, newline=True, tb=False, **kwargs):
         exc_info = 1
     else:
         exc_info = sys.exc_info()
-        msg = u'%s: %s' % (repr(exc_info[1]).split('(')[0],
+        msg = u'{0!s}: {1!s}'.format(repr(exc_info[1]).split('(')[0],
                            unicode(exc_info[1]).strip())
     if tb:
         kwargs['exc_info'] = exc_info

--- a/pywikibot/login.py
+++ b/pywikibot/login.py
@@ -94,12 +94,11 @@ class LoginManager(object):
                 self.username = self.username or family_sysopnames['*']
             except KeyError:
                 raise NoUsername(u"""\
-ERROR: Sysop username for %(fam_name)s:%(wiki_code)s is undefined.
+ERROR: Sysop username for {fam_name!s}:{wiki_code!s} is undefined.
 If you have a sysop account for that site, please add a line to user-config.py:
 
-sysopnames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
-                                 % {'fam_name': self.site.family.name,
-                                    'wiki_code': self.site.code})
+sysopnames['{fam_name!s}']['{wiki_code!s}'] = 'myUsername'""".format(**{'fam_name': self.site.family.name,
+                                    'wiki_code': self.site.code}))
         else:
             try:
                 family_usernames = config.usernames[self.site.family.name]
@@ -107,12 +106,11 @@ sysopnames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
                 self.username = self.username or family_usernames['*']
             except:
                 raise NoUsername(u"""\
-ERROR: Username for %(fam_name)s:%(wiki_code)s is undefined.
+ERROR: Username for {fam_name!s}:{wiki_code!s} is undefined.
 If you have an account for that site, please add a line to user-config.py:
 
-usernames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
-                                 % {'fam_name': self.site.family.name,
-                                    'wiki_code': self.site.code})
+usernames['{fam_name!s}']['{wiki_code!s}'] = 'myUsername'""".format(**{'fam_name': self.site.family.name,
+                                    'wiki_code': self.site.code}))
         self.password = password
         if getattr(config, 'password_file', ''):
             self.readPassword()
@@ -128,16 +126,14 @@ usernames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
             user = next(iter(data))
         except pywikibot.data.api.APIError as e:
             if e.code == 'readapidenied':
-                pywikibot.warning('Could not check user %s exists on %s'
-                                  % (self.username, self.site))
+                pywikibot.warning('Could not check user {0!s} exists on {1!s}'.format(self.username, self.site))
                 return
             else:
                 raise
 
         if user['name'] != self.username:
             # Report the same error as server error code NotExists
-            raise NoUsername('Username \'%s\' does not exist on %s'
-                             % (self.username, self.site))
+            raise NoUsername('Username \'{0!s}\' does not exist on {1!s}'.format(self.username, self.site))
 
     def botAllowed(self):
         """
@@ -185,7 +181,7 @@ usernames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
         """
         # THIS IS OVERRIDDEN IN data/api.py
         filename = config.datafilepath('pywikibot.lwp')
-        pywikibot.debug(u"Storing cookies to %s" % filename,
+        pywikibot.debug(u"Storing cookies to {0!s}".format(filename),
                         _logger)
         f = open(filename, 'w')
         f.write(data)
@@ -271,18 +267,15 @@ usernames['%(fam_name)s']['%(wiki_code)s'] = 'myUsername'"""
                 u'be shown):' % {'name': self.username, 'site': self.site},
                 password=True)
 
-        pywikibot.output(u"Logging in to %(site)s as %(name)s"
-                         % {'name': self.username, 'site': self.site})
+        pywikibot.output(u"Logging in to {site!s} as {name!s}".format(**{'name': self.username, 'site': self.site}))
         try:
             cookiedata = self.getCookie()
         except pywikibot.data.api.APIError as e:
-            pywikibot.error(u"Login failed (%s)." % e.code)
+            pywikibot.error(u"Login failed ({0!s}).".format(e.code))
             if e.code == 'NotExists':
-                raise NoUsername(u"Username '%s' does not exist on %s"
-                                 % (self.username, self.site))
+                raise NoUsername(u"Username '{0!s}' does not exist on {1!s}".format(self.username, self.site))
             elif e.code == 'Illegal':
-                raise NoUsername(u"Username '%s' is invalid on %s"
-                                 % (self.username, self.site))
+                raise NoUsername(u"Username '{0!s}' is invalid on {1!s}".format(self.username, self.site))
             # TODO: investigate other unhandled API codes (bug T75539)
             if retry:
                 self.password = None
@@ -336,7 +329,7 @@ class OauthLoginManager(LoginManager):
         @raises OAuthImpossible: mwoauth isn't installed
         """
         if isinstance(mwoauth, ImportError):
-            raise OAuthImpossible('mwoauth is not installed: %s.' % mwoauth)
+            raise OAuthImpossible('mwoauth is not installed: {0!s}.'.format(mwoauth))
         assert password is not None and user is not None
         assert sysop is False
         super(OauthLoginManager, self).__init__(None, False, site, None)
@@ -357,9 +350,8 @@ class OauthLoginManager(LoginManager):
         @type force: bool
         """
         if self.access_token is None or force:
-            pywikibot.output('Logging in to %(site)s via OAuth consumer %(key)s'
-                             % {'key': self.consumer_token[0],
-                                'site': self.site})
+            pywikibot.output('Logging in to {site!s} via OAuth consumer {key!s}'.format(**{'key': self.consumer_token[0],
+                                'site': self.site}))
             consumer_token = mwoauth.ConsumerToken(self.consumer_token[0],
                                                    self.consumer_token[1])
             handshaker = mwoauth.Handshaker(
@@ -380,9 +372,8 @@ class OauthLoginManager(LoginManager):
                 if retry:
                     self.login(retry=True, force=force)
         else:
-            pywikibot.output('Logged in to %(site)s via consumer %(key)s'
-                             % {'key': self.consumer_token[0],
-                                'site': self.site})
+            pywikibot.output('Logged in to {site!s} via consumer {key!s}'.format(**{'key': self.consumer_token[0],
+                                'site': self.site}))
 
     @property
     def consumer_token(self):

--- a/pywikibot/page.py
+++ b/pywikibot/page.py
@@ -148,8 +148,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
             self._revisions = {}
         else:
             raise pywikibot.Error(
-                "Invalid argument type '%s' in Page constructor: %s"
-                % (type(source), source))
+                "Invalid argument type '{0!s}' in Page constructor: {1!s}".format(type(source), source))
 
     @property
     def site(self):
@@ -266,21 +265,21 @@ class BasePage(UnicodeMixin, ComparableMixin):
                  self.site.code != target_code)):
                 if self.site.family.name != target_family \
                    and self.site.family.name != self.site.code:
-                    title = u'%s:%s:%s' % (self.site.family.name,
+                    title = u'{0!s}:{1!s}:{2!s}'.format(self.site.family.name,
                                            self.site.code,
                                            title)
                 else:
                     # use this form for sites like commons, where the
                     # code is the same as the family name
-                    title = u'%s:%s' % (self.site.code, title)
+                    title = u'{0!s}:{1!s}'.format(self.site.code, title)
             elif textlink and (self.isImage() or self.isCategory()):
-                title = u':%s' % title
+                title = u':{0!s}'.format(title)
             elif self.namespace() == 0 and not section:
                 withNamespace = True
             if withNamespace:
-                return u'[[%s%s]]' % (title, section)
+                return u'[[{0!s}{1!s}]]'.format(title, section)
             else:
-                return u'[[%s%s|%s]]' % (title, section, label)
+                return u'[[{0!s}{1!s}|{2!s}]]'.format(title, section, label)
         if not withNamespace and self.namespace() != 0:
             title = label + section
         else:
@@ -466,8 +465,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
         @param oldid: The revid of the revision desired.
         @rtype: unicode
         """
-        return "//%s%s/index.php?title=%s&oldid=%s" \
-               % (self.site.hostname(),
+        return "//{0!s}{1!s}/index.php?title={2!s}&oldid={3!s}".format(self.site.hostname(),
                   self.site.scriptpath(),
                   self.title(asUrl=True),
                   (oldid if oldid is not None else self.latest_revision_id))
@@ -768,14 +766,12 @@ class BasePage(UnicodeMixin, ComparableMixin):
                             self._catredirect = p.title()
                         else:
                             pywikibot.warning(
-                                u"Target %s on %s is not a category"
-                                % (p.title(asLink=True),
+                                u"Target {0!s} on {1!s} is not a category".format(p.title(asLink=True),
                                    self.title(asLink=True)))
                             self._catredirect = False
                     except IndexError:
                         pywikibot.warning(
-                            u"No target for category redirect on %s"
-                            % self.title(asLink=True))
+                            u"No target for category redirect on {0!s}".format(self.title(asLink=True)))
                         self._catredirect = False
                     break
             else:
@@ -831,11 +827,11 @@ class BasePage(UnicodeMixin, ComparableMixin):
                 return Page(self.site, self.title(withNamespace=False))
             else:
                 return Page(self.site,
-                            "%s:%s" % (self.site.namespace(ns - 1),
+                            "{0!s}:{1!s}".format(self.site.namespace(ns - 1),
                                        self.title(withNamespace=False)))
         else:
             return Page(self.site,
-                        "%s:%s" % (self.site.namespace(ns + 1),
+                        "{0!s}:{1!s}".format(self.site.namespace(ns + 1),
                                    self.title(withNamespace=False)))
 
     def isCategory(self):
@@ -1178,14 +1174,14 @@ class BasePage(UnicodeMixin, ComparableMixin):
                                       watch=watch, bot=botflag, **kwargs)
             if not done:
                 if not quiet:
-                    pywikibot.warning(u"Page %s not saved" % link)
+                    pywikibot.warning(u"Page {0!s} not saved".format(link))
                 raise pywikibot.PageNotSaved(self)
             if not quiet:
-                pywikibot.output(u"Page %s saved" % link)
+                pywikibot.output(u"Page {0!s} saved".format(link))
         # TODO: other "expected" error types to catch?
         except pywikibot.Error as edit_err:
             err = edit_err  # edit_err will be deleted in the end of the scope
-            pywikibot.log(u"Error saving page %s (%s)\n" % (link, err),
+            pywikibot.log(u"Error saving page {0!s} ({1!s})\n".format(link, err),
                           exc_info=True)
             if not callback and not async:
                 if isinstance(err, pywikibot.PageSaveRelatedError):
@@ -1215,8 +1211,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
         # cc depends on page directly and via several other imports
         from pywikibot.cosmetic_changes import CosmeticChangesToolkit  # noqa
         old = self.text
-        pywikibot.log(u'Cosmetic changes for %s-%s enabled.'
-                      % (family, self.site.lang))
+        pywikibot.log(u'Cosmetic changes for {0!s}-{1!s} enabled.'.format(family, self.site.lang))
         ccToolkit = CosmeticChangesToolkit(self.site,
                                            redirect=self.isRedirectPage(),
                                            namespace=self.namespace(),
@@ -1723,8 +1718,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
             (if there is one) and then move this page to that title
         """
         if reason is None:
-            pywikibot.output(u'Moving %s to [[%s]].'
-                             % (self.title(asLink=True), newtitle))
+            pywikibot.output(u'Moving {0!s} to [[{1!s}]].'.format(self.title(asLink=True), newtitle))
             reason = pywikibot.input(u'Please enter a reason for the move:')
         # TODO: implement "safe" parameter (Is this necessary ?)
         # TODO: implement "sysop" parameter
@@ -1745,7 +1739,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
             will be asked before marking pages for deletion.
         """
         if reason is None:
-            pywikibot.output(u'Deleting %s.' % (self.title(asLink=True)))
+            pywikibot.output(u'Deleting {0!s}.'.format((self.title(asLink=True))))
             reason = pywikibot.input(u'Please enter a reason for the deletion:')
 
         # If user is a sysop, delete the page
@@ -1753,8 +1747,8 @@ class BasePage(UnicodeMixin, ComparableMixin):
             answer = u'y'
             if prompt and not hasattr(self.site, '_noDeletePrompt'):
                 answer = pywikibot.input_choice(
-                    u'Do you want to delete %s?' % self.title(
-                        asLink=True, forceInterwiki=True),
+                    u'Do you want to delete {0!s}?'.format(self.title(
+                        asLink=True, forceInterwiki=True)),
                     [('Yes', 'y'), ('No', 'n'), ('All', 'a')],
                     'n', automatic_quit=False)
                 if answer == 'a':
@@ -1776,7 +1770,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
                     answer = 'y'
                     self.site._noMarkDeletePrompt = True
             if answer == 'y':
-                template = '{{delete|1=%s}}\n' % reason
+                template = '{{{{delete|1={0!s}}}}}\n'.format(reason)
                 self.text = template + self.text
                 return self.save(summary=reason)
 
@@ -1831,7 +1825,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
         if not hasattr(self, "_deletedRevs"):
             self.loadDeletedRevisions()
         if timestamp not in self._deletedRevs:
-            raise ValueError(u'Timestamp %d is not a deleted revision' % timestamp)
+            raise ValueError(u'Timestamp {0:d} is not a deleted revision'.format(timestamp))
         self._deletedRevs[timestamp]['marked'] = undelete
 
     @deprecate_arg('throttle', None)
@@ -1867,7 +1861,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
         if reason is None:
             warn('Not passing a reason for undelete() is deprecated.',
                  DeprecationWarning)
-            pywikibot.output(u'Undeleting %s.' % (self.title(asLink=True)))
+            pywikibot.output(u'Undeleting {0!s}.'.format((self.title(asLink=True))))
             reason = pywikibot.input(u'Please enter a reason for the undeletion:')
         self.site.undelete_page(self, reason, undelete_revs)
 
@@ -1921,8 +1915,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
         process_deprecated_arg(upload, "upload")
 
         if reason is None:
-            pywikibot.output(u'Preparing to protection change of %s.'
-                             % (self.title(asLink=True)))
+            pywikibot.output(u'Preparing to protection change of {0!s}.'.format((self.title(asLink=True))))
             reason = pywikibot.input(u'Please enter a reason for the action:')
         if unprotect:
             warn(u'"unprotect" argument of protect() is deprecated',
@@ -1936,8 +1929,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
                  DeprecationWarning, 2)
         if prompt and not hasattr(self.site, '_noProtectPrompt'):
             answer = pywikibot.input_choice(
-                u'Do you want to change the protection level of %s?'
-                % self.title(asLink=True, forceInterwiki=True),
+                u'Do you want to change the protection level of {0!s}?'.format(self.title(asLink=True, forceInterwiki=True)),
                 [('Yes', 'y'), ('No', 'n'), ('All', 'a')],
                 'n', automatic_quit=False)
             if answer == 'a':
@@ -1983,13 +1975,11 @@ class BasePage(UnicodeMixin, ComparableMixin):
                 cats.append(cat)
 
         if not self.canBeEdited():
-            pywikibot.output(u"Can't edit %s, skipping it..."
-                             % self.title(asLink=True))
+            pywikibot.output(u"Can't edit {0!s}, skipping it...".format(self.title(asLink=True)))
             return False
 
         if oldCat not in cats:
-            pywikibot.error(u'%s is not in category %s!'
-                            % (self.title(asLink=True), oldCat.title()))
+            pywikibot.error(u'{0!s} is not in category {1!s}!'.format(self.title(asLink=True), oldCat.title()))
             return False
 
         # This prevents the bot from adding newCat if it is already present.
@@ -2025,8 +2015,7 @@ class BasePage(UnicodeMixin, ComparableMixin):
                 self.put(newtext, comment)
                 return True
             except pywikibot.PageSaveRelatedError as error:
-                pywikibot.output(u'Page %s not saved: %s'
-                                 % (self.title(asLink=True),
+                pywikibot.output(u'Page {0!s} not saved: {1!s}'.format(self.title(asLink=True),
                                     error))
             except pywikibot.NoUsername:
                 pywikibot.output(u'Page %s not saved; sysop privileges '
@@ -2168,7 +2157,7 @@ class Page(BasePage):
                             named[str(k)] = intkeys[k]
                     break
             for name in named:
-                positional.append("%s=%s" % (name, named[name]))
+                positional.append("{0!s}={1!s}".format(name, named[name]))
             result.append((pywikibot.Page(link, self.site), positional))
         return result
 
@@ -2243,7 +2232,7 @@ class FilePage(Page):
         self._file_revisions = {}  # dictionary to cache File history.
         super(FilePage, self).__init__(source, title, 6)
         if self.namespace() != 6:
-            raise ValueError(u"'%s' is not in the file namespace!" % title)
+            raise ValueError(u"'{0!s}' is not in the file namespace!".format(title))
 
     def _load_file_revisions(self, imageinfo):
         for file_rev in imageinfo:
@@ -2301,8 +2290,7 @@ class FilePage(Page):
         same FilePage object, the page will only be downloaded once.
         """
         if not hasattr(self, '_imagePageHtml'):
-            path = "%s/index.php?title=%s" \
-                   % (self.site.scriptpath(), self.title(asUrl=True))
+            path = "{0!s}/index.php?title={1!s}".format(self.site.scriptpath(), self.title(asUrl=True))
             self._imagePageHtml = http.request(self.site, path)
         return self._imagePageHtml
 
@@ -2391,11 +2379,10 @@ class FilePage(Page):
         for info in self.getFileVersionHistory():
             datetime = info['timestamp']
             username = info['user']
-            resolution = '%dx%d' % (info['height'], info['width'])
+            resolution = '{0:d}x{1:d}'.format(info['height'], info['width'])
             size = info['size']
             comment = info['comment']
-            lines.append(u'| %s || %s || %s || %s || <nowiki>%s</nowiki>'
-                         % (datetime, username, resolution, size, comment))
+            lines.append(u'| {0!s} || {1!s} || {2!s} || {3!s} || <nowiki>{4!s}</nowiki>'.format(datetime, username, resolution, size, comment))
         return ('{| border="1"\n! date/time || username || resolution || size '
                 '|| edit summary\n|----\n\n|----\n'.join(lines) + '\n|}')
 
@@ -2429,8 +2416,7 @@ class Category(Page):
         self.sortKey = sortKey
         Page.__init__(self, source, title, ns=14)
         if self.namespace() != 14:
-            raise ValueError(u"'%s' is not in the category namespace!"
-                             % title)
+            raise ValueError(u"'{0!s}' is not in the category namespace!".format(title))
 
     @deprecated_args(forceInterwiki=None, textlink=None, noInterwiki=None)
     def aslink(self, sortKey=None):
@@ -2446,11 +2432,11 @@ class Category(Page):
         """
         key = sortKey or self.sortKey
         if key is not None:
-            titleWithSortKey = '%s|%s' % (self.title(withSection=False),
+            titleWithSortKey = '{0!s}|{1!s}'.format(self.title(withSection=False),
                                           key)
         else:
             titleWithSortKey = self.title(withSection=False)
-        return '[[%s]]' % titleWithSortKey
+        return '[[{0!s}]]'.format(titleWithSortKey)
 
     @deprecated_args(startFrom=None, cacheResults=None, step=None)
     def subcategories(self, recurse=False, total=None, content=False):
@@ -2647,13 +2633,11 @@ class Category(Page):
         else:
             targetCat = cat
         if targetCat.exists():
-            pywikibot.output(u'Target page %s already exists!'
-                             % targetCat.title(),
+            pywikibot.output(u'Target page {0!s} already exists!'.format(targetCat.title()),
                              level=pywikibot.logging.WARNING)
             return False
         else:
-            pywikibot.output('Moving text from %s to %s.'
-                             % (self.title(), targetCat.title()))
+            pywikibot.output('Moving text from {0!s} to {1!s}.'.format(self.title(), targetCat.title()))
             authors = ', '.join(self.contributingUsers())
             try:
                 creationSummary = message % (self.title(), authors)
@@ -2687,18 +2671,16 @@ class Category(Page):
         catname = self.site.namespaces.CATEGORY + ':' + catname
         targetCat = Category(self.site, catname)
         if targetCat.exists():
-            pywikibot.warning(u'Target page %s already exists!'
-                              % targetCat.title())
+            pywikibot.warning(u'Target page {0!s} already exists!'.format(targetCat.title()))
             return False
         else:
             pywikibot.output(
-                'Moving text from %s to %s.'
-                % (self.title(), targetCat.title()))
+                'Moving text from {0!s} to {1!s}.'.format(self.title(), targetCat.title()))
             authors = ', '.join(self.contributingUsers())
             creationSummary = message % (self.title(), authors)
             newtext = self.get()
         for regexName in cfdTemplates:
-            matchcfd = re.compile(r"{{%s.*?}}" % regexName, re.IGNORECASE)
+            matchcfd = re.compile(r"{{{{{0!s}.*?}}}}".format(regexName), re.IGNORECASE)
             newtext = matchcfd.sub('', newtext)
             matchcomment = re.compile(
                 r"<!--BEGIN CFD TEMPLATE-->.*?<!--END CFD TEMPLATE-->",
@@ -2839,8 +2821,7 @@ class User(Page):
             self._isAutoblock = False
         Page.__init__(self, source, title, ns=2)
         if self.namespace() != 2:
-            raise ValueError(u"'%s' is not in the user namespace!"
-                             % title)
+            raise ValueError(u"'{0!s}' is not in the user namespace!".format(title))
         if self._isAutoblock:
             # This user is probably being queried for purpose of lifting
             # an autoblock.
@@ -3052,7 +3033,7 @@ class User(Page):
         @rtype: bool
         """
         if not self.isEmailable():
-            raise NotEmailableError('%s is not mailable' % self.username)
+            raise NotEmailableError('{0!s} is not mailable'.format(self.username))
 
         if not self.site.has_right('sendemail'):
             raise UserRightsError('You don\'t have permission to send mail')
@@ -3130,7 +3111,7 @@ class User(Page):
                                 autoblock, noemail, reblock)
         except pywikibot.data.api.APIError as err:
             if err.code == 'invalidrange':
-                raise ValueError("%s is not a valid IP range." % self.username)
+                raise ValueError("{0!s} is not a valid IP range.".format(self.username))
             else:
                 raise err
 
@@ -3252,8 +3233,7 @@ class WikibasePage(BasePage):
                 elif site.property_namespace.id == ns:
                     self._namespace = site.property_namespace
                 else:
-                    raise ValueError('%r: Namespace "%d" is not valid'
-                                     % self.site)
+                    raise ValueError('{0!r}: Namespace "{1:d}" is not valid'.format(*self.site))
 
         if 'entity_type' in kwargs:
             entity_type = kwargs.pop('entity_type')
@@ -3262,8 +3242,7 @@ class WikibasePage(BasePage):
             elif entity_type == 'property':
                 entity_type_ns = site.property_namespace
             else:
-                raise ValueError('Wikibase entity type "%s" unknown'
-                                 % entity_type)
+                raise ValueError('Wikibase entity type "{0!s}" unknown'.format(entity_type))
 
             if self._namespace:
                 if self._namespace != entity_type_ns:
@@ -3284,8 +3263,7 @@ class WikibasePage(BasePage):
 
         if self._namespace:
             if self._link.namespace != self._namespace.id:
-                raise ValueError(u"'%s' is not in the namespace %d"
-                                 % (title, self._namespace.id))
+                raise ValueError(u"'{0!s}' is not in the namespace {1:d}".format(title, self._namespace.id))
         else:
             # Neither ns or entity_type was provided.
             # Use the _link to determine entity type.
@@ -3295,8 +3273,7 @@ class WikibasePage(BasePage):
             elif self.site.property_namespace.id == ns:
                 self._namespace = self.site.property_namespace
             else:
-                raise ValueError('%r: Namespace "%r" is not valid'
-                                 % (self.site, ns))
+                raise ValueError('{0!r}: Namespace "{1!r}" is not valid'.format(self.site, ns))
 
         # .site forces a parse of the Link title to determine site
         self.repo = self.site
@@ -3345,10 +3322,8 @@ class WikibasePage(BasePage):
             # if none of the above applies, this item is in an invalid state
             # which needs to be raise as an exception, but also logged in case
             # an exception handler is catching the generic Error.
-            pywikibot.error('%s is in invalid state'
-                            % self.__class__.__name__)
-            raise pywikibot.Error('%s is in invalid state'
-                                  % self.__class__.__name__)
+            pywikibot.error('{0!s} is in invalid state'.format(self.__class__.__name__))
+            raise pywikibot.Error('{0!s} is in invalid state'.format(self.__class__.__name__))
 
         return params
 
@@ -3775,8 +3750,7 @@ class ItemPage(WikibasePage):
         # Validate the title is 'Q' and a positive integer.
         if not re.match(r'^Q[1-9]\d*$', self._link.title):
             raise pywikibot.InvalidTitle(
-                u"'%s' is not a valid item page title"
-                % self._link.title)
+                u"'{0!s}' is not a valid item page title".format(self._link.title))
 
         assert self.id == self._link.title
 
@@ -3829,8 +3803,7 @@ class ItemPage(WikibasePage):
         @raise NoPage: There is no corresponding ItemPage for the page
         """
         if not page.site.has_transcluded_data:
-            raise pywikibot.WikiBaseError(u'%s has no transcluded data'
-                                          % page.site)
+            raise pywikibot.WikiBaseError(u'{0!s} has no transcluded data'.format(page.site))
         if not lazy_load and not page.exists():
             raise pywikibot.NoPage(page)
 
@@ -4170,7 +4143,7 @@ class PropertyPage(WikibasePage, Property):
                               ns=source.property_namespace)
         if not title or not self.id.startswith('P'):
             raise pywikibot.InvalidTitle(
-                u"'%s' is not an property page title" % title)
+                u"'{0!s}' is not an property page title".format(title))
         Property.__init__(self, source, self.id)
 
     def get(self, force=False, *args, **kwargs):
@@ -4390,8 +4363,7 @@ class Claim(Property):
         """
         value_class = self.types[self.type]
         if not isinstance(value, value_class):
-            raise ValueError("%s is not type %s."
-                             % (value, value_class))
+            raise ValueError("{0!s} is not type {1!s}.".format(value, value_class))
         self.target = value
 
     def changeTarget(self, value=None, snaktype='value', **kwargs):
@@ -4641,8 +4613,7 @@ class Claim(Property):
                            'quantity', 'monolingualtext'):
             value = self.getTarget().toWikibase()
         else:
-            raise NotImplementedError('%s datatype is not supported yet.'
-                                      % self.type)
+            raise NotImplementedError('{0!s} datatype is not supported yet.'.format(self.type))
         return value
 
     def _formatDataValue(self):
@@ -4729,8 +4700,7 @@ class Revision(DotReadableDict):
         """
         if self._parent_id is None:
             raise AssertionError(
-                'Revision %d was instantiated without a parent id'
-                % self.revid)
+                'Revision {0:d} was instantiated without a parent id'.format(self.revid))
 
         return self._parent_id
 
@@ -4747,8 +4717,7 @@ class Revision(DotReadableDict):
         # TODO: T102735: Add a sane default of 'wikitext' and others for <1.21
         if self._content_model is None:
             raise AssertionError(
-                'Revision %d was instantiated without a content model'
-                % self.revid)
+                'Revision {0:d} was instantiated without a content model'.format(self.revid))
 
         return self._content_model
 
@@ -4934,7 +4903,7 @@ class Link(ComparableMixin):
 
     def __repr__(self):
         """Return a more complete string representation."""
-        return "pywikibot.page.Link(%r, %r)" % (self.title, self.site)
+        return "pywikibot.page.Link({0!r}, {1!r})".format(self.title, self.site)
 
     def parse_site(self):
         """
@@ -5057,7 +5026,7 @@ class Link(ComparableMixin):
         m = Link.illegal_titles_pattern.search(t)
         if m:
             raise pywikibot.InvalidTitle(
-                u"%s contains illegal char(s) %s" % (repr(t), repr(m.group(0))))
+                u"{0!s} contains illegal char(s) {1!s}".format(repr(t), repr(m.group(0))))
 
         # Pages with "/./" or "/../" appearing in the URLs will
         # often be unreachable due to the way web browsers deal
@@ -5073,15 +5042,14 @@ class Link(ComparableMixin):
                 t.endswith(u'/..')
         ):
             raise pywikibot.InvalidTitle(
-                u"(contains . / combinations): '%s'"
-                % self._text)
+                u"(contains . / combinations): '{0!s}'".format(self._text))
 
         # Magic tilde sequences? Nu-uh!
         if u"~~~" in t:
-            raise pywikibot.InvalidTitle(u"(contains ~~~): '%s'" % self._text)
+            raise pywikibot.InvalidTitle(u"(contains ~~~): '{0!s}'".format(self._text))
 
         if self._namespace != -1 and len(t) > 255:
-            raise pywikibot.InvalidTitle(u"(over 255 bytes): '%s'" % t)
+            raise pywikibot.InvalidTitle(u"(over 255 bytes): '{0!s}'".format(t))
 
         # "empty" local links can only be self-links
         # with a fragment identifier.
@@ -5155,7 +5123,7 @@ class Link(ComparableMixin):
         """Return full page title, including localized namespace."""
         # Avoid that ':' will be added to the title for Main ns.
         if self.namespace != Namespace.MAIN:
-            return "%s:%s" % (self.site.namespace(self.namespace),
+            return "{0!s}:{1!s}".format(self.site.namespace(self.namespace),
                               self.title)
         else:
             return self.title
@@ -5182,11 +5150,10 @@ class Link(ComparableMixin):
             else:
                 # not found
                 raise pywikibot.Error(
-                    u'No corresponding namespace found for namespace %s on %s.'
-                    % (self.namespace, onsite))
+                    u'No corresponding namespace found for namespace {0!s} on {1!s}.'.format(self.namespace, onsite))
 
         if self.namespace != Namespace.MAIN:
-            return u'%s:%s' % (name, self.title)
+            return u'{0!s}:{1!s}'.format(name, self.title)
         else:
             return self.title
 
@@ -5206,15 +5173,15 @@ class Link(ComparableMixin):
         if self.section:
             title = title + "#" + self.section
         if onsite == self.site:
-            return u'[[%s]]' % title
+            return u'[[{0!s}]]'.format(title)
         if onsite.family == self.site.family:
-            return u'[[%s:%s]]' % (self.site.code, title)
+            return u'[[{0!s}:{1!s}]]'.format(self.site.code, title)
         if self.site.family.name == self.site.code:
             # use this form for sites like commons, where the
             # code is the same as the family name
-            return u'[[%s:%s]]' % (self.site.code,
+            return u'[[{0!s}:{1!s}]]'.format(self.site.code,
                                    title)
-        return u'[[%s:%s:%s]]' % (self.site.family.name,
+        return u'[[{0!s}:{1!s}:{2!s}]]'.format(self.site.family.name,
                                   self.site.code,
                                   title)
 
@@ -5248,7 +5215,7 @@ class Link(ComparableMixin):
 
     def __hash__(self):
         """A stable identifier to be used as a key in hash-tables."""
-        return hash(u'%s:%s:%s' % (self.site.family.name,
+        return hash(u'{0!s}:{1!s}:{2!s}'.format(self.site.family.name,
                                    self.site.code,
                                    self.title))
 
@@ -5439,7 +5406,7 @@ def UnicodeToAsciiHtml(s):
         if 31 < cord < 128:
             html.append(c)
         else:
-            html.append('&#%d;' % cord)
+            html.append('&#{0:d};'.format(cord))
     return ''.join(html)
 
 

--- a/pywikibot/pagegenerators.py
+++ b/pywikibot/pagegenerators.py
@@ -861,8 +861,7 @@ class GeneratorFactory(object):
                 valid_ql = ['{0}: {1}'.format(*i) for
                             i in self.site.proofread_levels.items()]
                 valid_ql = ', '.join(valid_ql)
-                pywikibot.warning('Acceptable values for -ql are:\n    %s'
-                                  % valid_ql)
+                pywikibot.warning('Acceptable values for -ql are:\n    {0!s}'.format(valid_ql))
             self.qualityfilter_list = value
             return True
         elif arg in ('-onlyif', '-onlyifnot'):
@@ -1417,7 +1416,7 @@ def PageTitleFilterPageGenerator(generator, ignore_list):
     for page in generator:
         if is_ignored(page):
             if config.verbose_output:
-                pywikibot.output('Ignoring page %s' % page.title())
+                pywikibot.output('Ignoring page {0!s}'.format(page.title()))
         else:
             yield page
 
@@ -1438,14 +1437,13 @@ def RedirectFilterPageGenerator(generator, no_redirects=True,
             if not page.isRedirectPage():
                 yield page
             elif show_filtered:
-                pywikibot.output(u'%s is a redirect page. Skipping.' % page)
+                pywikibot.output(u'{0!s} is a redirect page. Skipping.'.format(page))
 
         else:
             if page.isRedirectPage():
                 yield page
             elif show_filtered:
-                pywikibot.output(u'%s is not a redirect page. Skipping.'
-                                 % page)
+                pywikibot.output(u'{0!s} is not a redirect page. Skipping.'.format(page))
 
 
 DuplicateFilterPageGenerator = filter_unique
@@ -1465,7 +1463,7 @@ class ItemClaimFilter(object):
         @rtype: bool
         """
         if not isinstance(page, pywikibot.ItemPage):
-            pywikibot.output(u'%s is not an ItemPage. Skipping.' % page)
+            pywikibot.output(u'{0!s} is not an ItemPage. Skipping.'.format(page))
             return False
         for page_claim in page.get()['claims'][prop]:
             if page_claim.target_equals(claim):
@@ -1523,8 +1521,7 @@ def SubpageFilterGenerator(generator, max_depth=0, show_filtered=False):
         else:
             if show_filtered:
                 pywikibot.output(
-                    'Page %s is a subpage that is too deep. Skipping.'
-                    % page)
+                    'Page {0!s} is a subpage that is too deep. Skipping.'.format(page))
 
 
 class RegexFilter(object):
@@ -1689,15 +1686,13 @@ def EdittimeFilterPageGenerator(generator,
             if last_edit < last_edit_start:
                 if show_filtered:
                     pywikibot.output(
-                        u'Last edit on %s was on %s.\nToo old. Skipping.'
-                        % (page, last_edit.isoformat()))
+                        u'Last edit on {0!s} was on {1!s}.\nToo old. Skipping.'.format(page, last_edit.isoformat()))
                 continue
 
             if last_edit > last_edit_end:
                 if show_filtered:
                     pywikibot.output(
-                        u'Last edit on %s was on %s.\nToo recent. Skipping.'
-                        % (page, last_edit.isoformat()))
+                        u'Last edit on {0!s} was on {1!s}.\nToo recent. Skipping.'.format(page, last_edit.isoformat()))
                 continue
 
         if do_first_edit:
@@ -1706,14 +1701,12 @@ def EdittimeFilterPageGenerator(generator,
             if first_edit < first_edit_start:
                 if show_filtered:
                     pywikibot.output(
-                        u'First edit on %s was on %s.\nToo old. Skipping.'
-                        % (page, first_edit.isoformat()))
+                        u'First edit on {0!s} was on {1!s}.\nToo old. Skipping.'.format(page, first_edit.isoformat()))
 
             if first_edit > first_edit_end:
                 if show_filtered:
                     pywikibot.output(
-                        u'First edit on %s was on %s.\nToo recent. Skipping.'
-                        % (page, first_edit.isoformat()))
+                        u'First edit on {0!s} was on {1!s}.\nToo recent. Skipping.'.format(page, first_edit.isoformat()))
                 continue
 
         yield page
@@ -1753,7 +1746,7 @@ def UserEditFilterGenerator(generator, username, timestamp=None, skip=False,
         if bool(contribs[username]) is not bool(skip):  # xor operation
             yield page
         elif show_filtered:
-            pywikibot.output(u'Skipping %s' % page.title(asLink=True))
+            pywikibot.output(u'Skipping {0!s}'.format(page.title(asLink=True)))
 
 
 def CombinedPageGenerator(generators):
@@ -1908,8 +1901,7 @@ def PreloadingItemGenerator(generator, groupsize=50):
             datasite = page.site.data_repository()
             if page.namespace() != datasite.item_namespace:
                 pywikibot.output(
-                    u'PreloadingItemGenerator skipping %s as it is not in %s'
-                    % (page, datasite.item_namespace))
+                    u'PreloadingItemGenerator skipping {0!s} as it is not in {1!s}'.format(page, datasite.item_namespace))
                 continue
 
             page = pywikibot.ItemPage(datasite, page.title())
@@ -1993,13 +1985,13 @@ def WikibaseItemFilterPageGenerator(generator, has_item=True,
             if not has_item:
                 if show_filtered:
                     pywikibot.output(
-                        '%s has a wikidata item.  Skipping.' % page)
+                        '{0!s} has a wikidata item.  Skipping.'.format(page))
                 continue
         else:
             if has_item:
                 if show_filtered:
                     pywikibot.output(
-                        '%s doesn\'t have a wikidata item.  Skipping.' % page)
+                        '{0!s} doesn\'t have a wikidata item.  Skipping.'.format(page))
                 continue
 
         yield page
@@ -2299,8 +2291,8 @@ def UntaggedPageGenerator(untaggedProject, limit=500, site=None):
     if lang == 'commons':
         wiki = 'wikifam=commons.wikimedia.org'
     else:
-        wiki = 'wikilang=%s&wikifam=.%s' % (lang, project)
-    link = '%s&%s&max=%d&order=img_timestamp' % (URL, wiki, limit)
+        wiki = 'wikilang={0!s}&wikifam=.{1!s}'.format(lang, project)
+    link = '{0!s}&{1!s}&max={2:d}&order=img_timestamp'.format(URL, wiki, limit)
     results = re.findall(REGEXP, http.fetch(link))
     if not results:
         raise pywikibot.Error(
@@ -2393,8 +2385,8 @@ class YahooSearchPageGenerator(object):
     def __iter__(self):
         """Iterate results."""
         # restrict query to local site
-        localQuery = '%s site:%s' % (self.query, self.site.hostname())
-        base = 'http://%s%s' % (self.site.hostname(),
+        localQuery = '{0!s} site:{1!s}'.format(self.query, self.site.hostname())
+        base = 'http://{0!s}{1!s}'.format(self.site.hostname(),
                                 self.site.article_path)
         for url in self.queryYahoo(localQuery):
             if url[:len(base)] == base:
@@ -2461,8 +2453,8 @@ class GoogleSearchPageGenerator(object):
     def __iter__(self):
         """Iterate results."""
         # restrict query to local site
-        localQuery = '%s site:%s' % (self.query, self.site.hostname())
-        base = 'http://%s%s' % (self.site.hostname(),
+        localQuery = '{0!s} site:{1!s}'.format(self.query, self.site.hostname())
+        base = 'http://{0!s}{1!s}'.format(self.site.hostname(),
                                 self.site.article_path)
         for url in self.queryGoogle(localQuery):
             if url[:len(base)] == base:
@@ -2511,7 +2503,7 @@ def MySQLPageGenerator(query, site=None, verbose=None):
             namespace = site.namespace(int(namespaceNumber))
             pageName = pageName.decode(site.encoding())
             if namespace:
-                pageTitle = '%s:%s' % (namespace, pageName)
+                pageTitle = '{0!s}:{1!s}'.format(namespace, pageName)
             else:
                 pageTitle = pageName
             page = pywikibot.Page(site, pageTitle)
@@ -2583,10 +2575,10 @@ def YearPageGenerator(start=1, end=2050, site=None):
     """
     if site is None:
         site = pywikibot.Site()
-    pywikibot.output(u"Starting with year %i" % start)
+    pywikibot.output(u"Starting with year {0:d}".format(start))
     for i in range(start, end + 1):
         if i % 100 == 0:
-            pywikibot.output(u'Preparing %i...' % i)
+            pywikibot.output(u'Preparing {0:d}...'.format(i))
         # There is no year 0
         if i != 0:
             current_year = date.formatYear(site.lang, i)
@@ -2606,7 +2598,7 @@ def DayPageGenerator(startMonth=1, endMonth=12, site=None, year=2000):
         site = pywikibot.Site()
     fd = date.FormatDate(site)
     firstPage = pywikibot.Page(site, fd(startMonth, 1))
-    pywikibot.output(u"Starting with %s" % firstPage.title(asLink=True))
+    pywikibot.output(u"Starting with {0!s}".format(firstPage.title(asLink=True)))
     for month in range(startMonth, endMonth + 1):
         for day in range(1, calendar.monthrange(year, month)[1] + 1):
             yield pywikibot.Page(pywikibot.Link(fd(month, day), site))
@@ -2654,12 +2646,12 @@ def WikidataQueryPageGenerator(query, site=None):
 
     if not is_repo:
         # limit the results to those with sitelinks to target site
-        query += ' link[%s]' % site.dbName()
+        query += ' link[{0!s}]'.format(site.dbName())
     wd_queryset = wdquery.QuerySet(query)
 
     wd_query = wdquery.WikidataQuery(cacheMaxAge=0)
     data = wd_query.query(wd_queryset)
-    pywikibot.output(u'retrieved %d items' % data[u'status'][u'items'])
+    pywikibot.output(u'retrieved {0:d} items'.format(data[u'status'][u'items']))
     items_pages = (pywikibot.ItemPage(repo, 'Q{0}'.format(item))
                    for item in data[u'items'])
     if is_repo:
@@ -2715,7 +2707,7 @@ def WikibaseSearchItemPageGenerator(text, language=None, total=None, site=None):
     repo = site.data_repository()
 
     data = repo.search_entities(text, language, limit=total)
-    pywikibot.output(u'retrieved %d items' % len(list(data)))
+    pywikibot.output(u'retrieved {0:d} items'.format(len(list(data))))
     for item in data:
         yield pywikibot.ItemPage(repo, item['id'])
 

--- a/pywikibot/proofreadpage.py
+++ b/pywikibot/proofreadpage.py
@@ -94,12 +94,10 @@ class ProofreadPage(pywikibot.Page):
             site = source
         super(ProofreadPage, self).__init__(source, title)
         if self.namespace() != site.proofread_page_ns:
-            raise ValueError('Page %s must belong to %s namespace'
-                             % (self.title(), site.proofread_page_ns))
+            raise ValueError('Page {0!s} must belong to {1!s} namespace'.format(self.title(), site.proofread_page_ns))
         # Ensure that constants are in line with Extension values.
         if list(self.site.proofread_levels.keys()) != self.PROOFREAD_LEVELS:
-            raise ValueError('QLs do not match site values: %s != %s'
-                             % (self.site.proofread_levels.keys(),
+            raise ValueError('QLs do not match site values: {0!s} != {1!s}'.format(self.site.proofread_levels.keys(),
                                 self.PROOFREAD_LEVELS))
 
     @property
@@ -138,22 +136,19 @@ class ProofreadPage(pywikibot.Page):
 
         page, others = self._index
         if others:
-            pywikibot.warning('Page %s is linked to several Index pages: %s.'
-                              % (self, others))
+            pywikibot.warning('Page {0!s} is linked to several Index pages: {1!s}.'.format(self, others))
             if page:
-                pywikibot.warning('    %s selected as Index.' % page)
-                pywikibot.warning('    %s remaining.' % others)
+                pywikibot.warning('    {0!s} selected as Index.'.format(page))
+                pywikibot.warning('    {0!s} remaining.'.format(others))
         elif not page:
-            pywikibot.warning('Page %s is not linked to any Index page.'
-                              % self)
+            pywikibot.warning('Page {0!s} is not linked to any Index page.'.format(self))
 
         return page
 
     @index.setter
     def index(self, value):
         if not isinstance(value, IndexPage):
-            raise ValueError('value %s must be a IndexPage object.'
-                             % value)
+            raise ValueError('value {0!s} must be a IndexPage object.'.format(value))
         self._index = (value, None)
 
     @index.deleter
@@ -205,8 +200,7 @@ class ProofreadPage(pywikibot.Page):
     def ql(self, value):
         """Set page quality level."""
         if value not in self.site.proofread_levels:
-            raise ValueError('Not valid QL value: %s (legal values: %s)'
-                             % (value, self.site.proofread_levels))
+            raise ValueError('Not valid QL value: {0!s} (legal values: {1!s})'.format(value, self.site.proofread_levels))
         # TODO: add logic to validate ql value change, considering
         # site.proofread_levels.
         self._full_header.ql = value
@@ -230,8 +224,7 @@ class ProofreadPage(pywikibot.Page):
         try:
             return self.site.proofread_levels[self.ql]
         except KeyError:
-            pywikibot.warning('Not valid status set for %s: quality level = %s'
-                              % (self.title(asLink=True), self.ql))
+            pywikibot.warning('Not valid status set for {0!s}: quality level = {1!s}'.format(self.title(asLink=True), self.ql))
             return None
 
     def without_text(self):
@@ -363,8 +356,7 @@ class ProofreadPage(pywikibot.Page):
         len_oq = len(open_queue)
         len_cq = len(close_queue)
         if (len_oq != len_cq) or (len_oq < 2 or len_cq < 2):
-            raise pywikibot.Error('ProofreadPage %s: invalid format'
-                                  % self.title(asLink=True))
+            raise pywikibot.Error('ProofreadPage {0!s}: invalid format'.format(self.title(asLink=True)))
 
         f_open, f_close = open_queue[0], close_queue[0]
         self._full_header = FullHeader(self._text[f_open.end():f_close.start()])
@@ -456,8 +448,7 @@ class IndexPage(pywikibot.Page):
             site = source
         super(IndexPage, self).__init__(source, title)
         if self.namespace() != site.proofread_index_ns:
-            raise ValueError('Page %s must belong to %s namespace'
-                             % (self.title(), site.proofread_index_ns))
+            raise ValueError('Page {0!s} must belong to {1!s} namespace'.format(self.title(), site.proofread_index_ns))
 
         self._all_page_links = set(
             self.site.pagelinks(self, namespaces=site.proofread_page_ns))
@@ -542,7 +533,7 @@ class IndexPage(pywikibot.Page):
                 continue
 
             if page not in self._all_page_links:
-                raise pywikibot.Error('Page %s not recognised.' % page)
+                raise pywikibot.Error('Page {0!s} not recognised.'.format(page))
 
             # In order to avoid to fetch other Page:title links outside
             # the Pages section of the Index page; these should hopefully be
@@ -555,8 +546,7 @@ class IndexPage(pywikibot.Page):
             # Sanity check if WS site use page convention name/number.
             if sep == '/':
                 assert page_cnt == int(page_number), (
-                    'Page number %s not recognised as page %s.'
-                    % (page_cnt, title))
+                    'Page number {0!s} not recognised as page {1!s}.'.format(page_cnt, title))
 
             # Mapping: numbers <-> pages.
             self._page_from_numbers[page_cnt] = page
@@ -609,8 +599,7 @@ class IndexPage(pywikibot.Page):
         if not ((1 <= start <= self.num_pages) and
                 (1 <= end <= self.num_pages) and
                 (start <= end)):
-            raise ValueError('start=%s, end=%s are not in valid range (%s, %s)'
-                             % (start, end, 1, self.num_pages))
+            raise ValueError('start={0!s}, end={1!s} are not in valid range ({2!s}, {3!s})'.format(start, end, 1, self.num_pages))
 
         # All but 'Without Text'
         if filter_ql is None:
@@ -646,7 +635,7 @@ class IndexPage(pywikibot.Page):
         try:
             return self._labels_from_page[page]
         except KeyError:
-            raise KeyError('Invalid Page: %s.' % page)
+            raise KeyError('Invalid Page: {0!s}.'.format(page))
 
     @check_if_cached
     def get_label_from_page_number(self, page_number):
@@ -661,8 +650,7 @@ class IndexPage(pywikibot.Page):
         try:
             return self._labels_from_page_number[page_number]
         except KeyError:
-            raise KeyError('Page number ".../%s" not in range.'
-                           % page_number)
+            raise KeyError('Page number ".../{0!s}" not in range.'.format(page_number))
 
     def _get_from_label(self, mapping_dict, label):
         """Helper function to get info from label."""
@@ -673,7 +661,7 @@ class IndexPage(pywikibot.Page):
         try:
             return mapping_dict[label]
         except KeyError:
-            raise KeyError('No page has label: "%s".' % label)
+            raise KeyError('No page has label: "{0!s}".'.format(label))
 
     @check_if_cached
     def get_page_number_from_label(self, label='1'):
@@ -703,7 +691,7 @@ class IndexPage(pywikibot.Page):
         try:
             return self._page_from_numbers[page_number]
         except KeyError:
-            raise KeyError('Invalid page number: %s.' % page_number)
+            raise KeyError('Invalid page number: {0!s}.'.format(page_number))
 
     @check_if_cached
     def pages(self):
@@ -720,4 +708,4 @@ class IndexPage(pywikibot.Page):
         try:
             return self._numbers_from_page[page]
         except KeyError:
-            raise KeyError('Invalid page: %s.' % page)
+            raise KeyError('Invalid page: {0!s}.'.format(page))

--- a/pywikibot/site.py
+++ b/pywikibot/site.py
@@ -120,8 +120,7 @@ class LoginStatus(object):
         for key, value in cls.__dict__.items():
             if key == key.upper() and value == search_value:
                 return key
-        raise KeyError("Value %r could not be found in this enum"
-                       % search_value)
+        raise KeyError("Value {0!r} could not be found in this enum".format(search_value))
 
     def __init__(self, state):
         """Constructor."""
@@ -129,7 +128,7 @@ class LoginStatus(object):
 
     def __repr__(self):
         """Return internal representation."""
-        return 'LoginStatus(%s)' % (LoginStatus.name(self.state))
+        return 'LoginStatus({0!s})'.format((LoginStatus.name(self.state)))
 
 
 Family = redirect_func(pywikibot.family.Family.load,
@@ -395,8 +394,7 @@ class Namespace(Iterable, ComparableMixin, UnicodeMixin):
         else:
             kwargs = ''
 
-        return '%s(id=%d, custom_name=%r, canonical_name=%r, aliases=%r%s)' \
-               % (self.__class__.__name__, self.id, self.custom_name,
+        return '{0!s}(id={1:d}, custom_name={2!r}, canonical_name={3!r}, aliases={4!r}{5!s})'.format(self.__class__.__name__, self.id, self.custom_name,
                   self.canonical_name, self.aliases, kwargs)
 
     @staticmethod
@@ -634,15 +632,13 @@ class NamespacesDict(Mapping, SelfCallMixin):
                   for ns in identifiers]
 
         if NotImplemented in result:
-            raise TypeError('identifiers contains inappropriate types: %r'
-                            % identifiers)
+            raise TypeError('identifiers contains inappropriate types: {0!r}'.format(identifiers))
 
         # Namespace.lookup_name returns None if the name is not recognised
         if None in result:
-            raise KeyError(u'Namespace identifier(s) not recognised: %s'
-                           % u','.join([str(identifier) for identifier, ns
+            raise KeyError(u'Namespace identifier(s) not recognised: {0!s}'.format(u','.join([str(identifier) for identifier, ns
                                         in zip(identifiers, result)
-                                        if ns is None]))
+                                        if ns is None])))
 
         return result
 
@@ -699,8 +695,7 @@ class _InterwikiMap(object):
         elif isinstance(self._iw_sites[prefix].site, Exception):
             raise self._iw_sites[prefix].site
         else:
-            raise TypeError('_iw_sites[%s] is wrong type: %s'
-                            % (prefix, type(self._iw_sites[prefix].site)))
+            raise TypeError('_iw_sites[{0!s}] is wrong type: {1!s}'.format(prefix, type(self._iw_sites[prefix].site)))
 
     def get_by_url(self, url):
         """Return a set of prefixes applying to the URL."""
@@ -728,11 +723,10 @@ class BaseSite(ComparableMixin):
         if code.lower() != code:
             # Note the Site function in __init__ also emits a UserWarning
             # for this condition, showing the callers file and line no.
-            pywikibot.log(u'BaseSite: code "%s" converted to lowercase' % code)
+            pywikibot.log(u'BaseSite: code "{0!s}" converted to lowercase'.format(code))
             code = code.lower()
         if not all(x in pywikibot.family.CODE_CHARACTERS for x in str(code)):
-            pywikibot.log(u'BaseSite: code "%s" contains invalid characters'
-                          % code)
+            pywikibot.log(u'BaseSite: code "{0!s}" contains invalid characters'.format(code))
         self.__code = code
         if isinstance(fam, basestring) or fam is None:
             self.__family = pywikibot.family.Family.load(fam)
@@ -746,8 +740,7 @@ class BaseSite(ComparableMixin):
                 self.__code = self.__family.obsolete[self.__code]
                 # Note the Site function in __init__ emits a UserWarning
                 # for this condition, showing the callers file and line no.
-                pywikibot.log(u'Site %s instantiated using code %s'
-                              % (self, code))
+                pywikibot.log(u'Site {0!s} instantiated using code {1!s}'.format(self, code))
             else:
                 # no such language anymore
                 self.obsolete = True
@@ -764,8 +757,7 @@ class BaseSite(ComparableMixin):
                          u'"%s" while instantiating site %s'
                          % (self.__code, self), UserWarning)
             else:
-                raise UnknownSite(u"Language '%s' does not exist in family %s"
-                                  % (self.__code, self.__family.name))
+                raise UnknownSite(u"Language '{0!s}' does not exist in family {1!s}".format(self.__code, self.__family.name))
 
         self._username = [normalize_username(user), normalize_username(sysop)]
 
@@ -895,8 +887,7 @@ class BaseSite(ComparableMixin):
                 f.__doc__ = method.__doc__
             return f
         except AttributeError:
-            raise AttributeError("%s instance has no attribute '%s'"
-                                 % (self.__class__.__name__, attr))
+            raise AttributeError("{0!s} instance has no attribute '{1!s}'".format(self.__class__.__name__, attr))
 
     def __str__(self):
         """Return string representing this Site's name and code."""
@@ -1080,11 +1071,10 @@ class BaseSite(ComparableMixin):
     def disambcategory(self):
         """Return Category in which disambig pages are listed."""
         try:
-            name = '%s:%s' % (self.namespace(14),
+            name = '{0!s}:{1!s}'.format(self.namespace(14),
                               self.family.disambcatname[self.code])
         except KeyError:
-            raise Error(u"No disambiguation category name found for %(site)s"
-                        % {'site': self})
+            raise Error(u"No disambiguation category name found for {site!s}".format(**{'site': self}))
         return pywikibot.Category(pywikibot.Link(name, self))
 
     @deprecated("pywikibot.Link")
@@ -1121,8 +1111,7 @@ class BaseSite(ComparableMixin):
         # A redirect starts with hash (#), followed by a keyword, then
         # arbitrary stuff, then a wikilink. The wikilink may contain
         # a label, although this is not useful.
-        return re.compile(r'\s*#%(pattern)s\s*:?\s*\[\[(.+?)(?:\|.*?)?\]\]'
-                          % {'pattern': pattern},
+        return re.compile(r'\s*#{pattern!s}\s*:?\s*\[\[(.+?)(?:\|.*?)?\]\]'.format(**{'pattern': pattern}),
                           re.IGNORECASE | re.UNICODE | re.DOTALL)
 
     def sametitle(self, title1, title2):
@@ -1293,8 +1282,7 @@ def must_be(group=None, right=None):
     def decorator(fn):
         def callee(self, *args, **kwargs):
             if self.obsolete:
-                raise UnknownSite("Language %s in family %s is obsolete"
-                                  % (self.code, self.family.name))
+                raise UnknownSite("Language {0!s} in family {1!s} is obsolete".format(self.code, self.family.name))
             grp = kwargs.pop('as_group', group)
             if grp == 'user':
                 self.login(False)
@@ -1352,8 +1340,7 @@ def need_extension(extension):
         def callee(self, *args, **kwargs):
             if not self.has_extension(extension):
                 raise UnknownExtension(
-                    'Method "%s" is not implemented without the extension %s'
-                    % (fn.__name__, extension))
+                    'Method "{0!s}" is not implemented without the extension {1!s}'.format(fn.__name__, extension))
             return fn(self, *args, **kwargs)
 
         if not __debug__:
@@ -1880,7 +1867,7 @@ class APISite(BaseSite):
                 for site in val:
                     if site['dbname'] == dbname:
                         return cls(site['code'], site['code'])
-        raise ValueError("Cannot parse a site out of %s." % dbname)
+        raise ValueError("Cannot parse a site out of {0!s}.".format(dbname))
 
     @deprecated
     def has_api(self):
@@ -2020,8 +2007,7 @@ class APISite(BaseSite):
         #       of issues are resolved.
         if self._loginstatus == LoginStatus.IN_PROGRESS:
             pywikibot.log(
-                u'%r.login(%r) called when a previous login was in progress.'
-                % (self, sysop)
+                u'{0!r}.login({1!r}) called when a previous login was in progress.'.format(self, sysop)
             )
         # There are several ways that the site may already be
         # logged in, and we do not need to hit the server again.
@@ -2051,7 +2037,7 @@ class APISite(BaseSite):
                                     'wrong': self.userinfo['name'],
                                     'right': self._username[sysop]})
             else:
-                raise NoUsername('Logging in on %s via OAuth failed' % self)
+                raise NoUsername('Logging in on {0!s} via OAuth failed'.format(self))
         loginMan = api.LoginManager(site=self, sysop=sysop,
                                     user=self._username[sysop])
         if loginMan.login(retry=True):
@@ -2185,7 +2171,7 @@ class APISite(BaseSite):
         """
         if self.is_blocked(sysop):
             # User blocked
-            raise UserBlocked('User is blocked in site %s' % self)
+            raise UserBlocked('User is blocked in site {0!s}'.format(self))
 
     def get_searched_namespaces(self, force=False):
         """
@@ -2233,11 +2219,11 @@ class APISite(BaseSite):
         if reverse:
             if end < start:
                 raise Error(
-                    "%s: end must be later than start with reverse=True" % msg_prefix)
+                    "{0!s}: end must be later than start with reverse=True".format(msg_prefix))
         else:
             if start < end:
                 raise Error(
-                    "%s: start must be later than end with reverse=False" % msg_prefix)
+                    "{0!s}: start must be later than end with reverse=False".format(msg_prefix))
 
     def has_right(self, right, sysop=False):
         """Return true if and only if the user has a specific right.
@@ -2338,8 +2324,7 @@ class APISite(BaseSite):
                 # Check requested keys
                 for key in keys:
                     if key not in self._msgcache:
-                        raise KeyError("Site %s has no message '%s'"
-                                       % (self, key))
+                        raise KeyError("Site {0!s} has no message '{1!s}'".format(self, key))
 
         return dict((_key, self._msgcache[_key]) for _key in keys)
 
@@ -2927,8 +2912,7 @@ class APISite(BaseSite):
         for pageitem in query:
             if not self.sametitle(pageitem['title'], title):
                 raise Error(
-                    u"loadimageinfo: Query on %s returned data on '%s'"
-                    % (page, pageitem['title']))
+                    u"loadimageinfo: Query on {0!s} returned data on '{1!s}'".format(page, pageitem['title']))
             api.update_page(page, pageitem, query.props)
 
             if "imageinfo" not in pageitem:
@@ -3025,8 +3009,7 @@ class APISite(BaseSite):
         result = query.submit()
         if "query" not in result or "redirects" not in result["query"]:
             raise RuntimeError(
-                "getredirtarget: No 'redirects' found for page %s."
-                % title.encode(self.encoding()))
+                "getredirtarget: No 'redirects' found for page {0!s}.".format(title.encode(self.encoding())))
 
         redirmap = dict((item['from'],
                          {'title': item['to'],
@@ -3043,9 +3026,8 @@ class APISite(BaseSite):
 
         if title not in redirmap:
             raise RuntimeError(
-                "getredirtarget: 'redirects' contains no key for page %s."
-                % title.encode(self.encoding()))
-        target_title = u'%(title)s%(section)s' % redirmap[title]
+                "getredirtarget: 'redirects' contains no key for page {0!s}.".format(title.encode(self.encoding())))
+        target_title = u'{title!s}{section!s}'.format(**redirmap[title])
 
         if self.sametitle(title, target_title):
             raise CircularRedirect(page)
@@ -3121,10 +3103,9 @@ class APISite(BaseSite):
             else:
                 rvgen.request["titles"] = "|".join(list(cache.keys()))
             rvgen.request[u"rvprop"] = u"ids|flags|timestamp|user|comment|content"
-            pywikibot.output(u"Retrieving %s pages from %s."
-                             % (len(cache), self))
+            pywikibot.output(u"Retrieving {0!s} pages from {1!s}.".format(len(cache), self))
             for pagedata in rvgen:
-                pywikibot.debug(u"Preloading %s" % pagedata, _logger)
+                pywikibot.debug(u"Preloading {0!s}".format(pagedata), _logger)
                 try:
                     if pagedata['title'] not in cache:
                         # API always returns a "normalized" title which is
@@ -3144,9 +3125,9 @@ class APISite(BaseSite):
                                 u"title '%s'" % pagedata['title'])
                             continue
                 except KeyError:
-                    pywikibot.debug(u"No 'title' in %s" % pagedata, _logger)
-                    pywikibot.debug(u"pageids=%s" % pageids, _logger)
-                    pywikibot.debug(u"titles=%s" % list(cache.keys()), _logger)
+                    pywikibot.debug(u"No 'title' in {0!s}".format(pagedata), _logger)
+                    pywikibot.debug(u"pageids={0!s}".format(pageids), _logger)
+                    pywikibot.debug(u"titles={0!s}".format(list(cache.keys())), _logger)
                     continue
                 page = cache[pagedata['title']]
                 api.update_page(page, pagedata, rvgen.props)
@@ -3598,8 +3579,7 @@ class APISite(BaseSite):
         """
         if category.namespace() != 14:
             raise Error(
-                u"categorymembers: non-Category page '%s' specified"
-                % category.title())
+                u"categorymembers: non-Category page '{0!s}' specified".format(category.title()))
         cmtitle = category.title(withSection=False).encode(self.encoding())
         cmargs = dict(type_arg="categorymembers",
                       gcmtitle=cmtitle,
@@ -3608,8 +3588,7 @@ class APISite(BaseSite):
             cmargs["gcmsort"] = sortby
         elif sortby:
             raise ValueError(
-                "categorymembers: invalid sortby value '%s'"
-                % sortby)
+                "categorymembers: invalid sortby value '{0!s}'".format(sortby))
         if starttime and endtime and starttime > endtime:
             raise ValueError(
                 "categorymembers: starttime must be before endtime")
@@ -3639,8 +3618,7 @@ class APISite(BaseSite):
                 if namespaces:
                     if excluded_namespaces.intersection(namespaces):
                         raise ValueError(
-                            'incompatible namespaces %r and member_type %r'
-                            % (namespaces, member_type))
+                            'incompatible namespaces {0!r} and member_type {1!r}'.format(namespaces, member_type))
                     # All excluded namespaces are not present in `namespaces`.
                 else:
                     # If the number of namespaces is greater than permitted by
@@ -3817,8 +3795,7 @@ class APISite(BaseSite):
             if not self.sametitle(pagedata['title'],
                                   page.title(withSection=False)):
                 raise Error(
-                    u"loadrevisions: Query on %s returned data on '%s'"
-                    % (page, pagedata['title']))
+                    u"loadrevisions: Query on {0!s} returned data on '{1!s}'".format(page, pagedata['title']))
             if "missing" in pagedata:
                 raise NoPage(page)
             api.update_page(page, pagedata, rvgen.props)
@@ -3848,8 +3825,7 @@ class APISite(BaseSite):
         for pageitem in llquery:
             if not self.sametitle(pageitem['title'], lltitle):
                 raise Error(
-                    u"getlanglinks: Query on %s returned data on '%s'"
-                    % (page, pageitem['title']))
+                    u"getlanglinks: Query on {0!s} returned data on '{1!s}'".format(page, pageitem['title']))
             if 'langlinks' not in pageitem:
                 continue
             for linkdata in pageitem['langlinks']:
@@ -3871,8 +3847,7 @@ class APISite(BaseSite):
         for pageitem in elquery:
             if not self.sametitle(pageitem['title'], eltitle):
                 raise RuntimeError(
-                    "getlanglinks: Query on %s returned data on '%s'"
-                    % (page, pageitem['title']))
+                    "getlanglinks: Query on {0!s} returned data on '{1!s}'".format(page, pageitem['title']))
             if 'extlinks' not in pageitem:
                 continue
             for linkdata in pageitem['extlinks']:
@@ -4477,7 +4452,7 @@ class APISite(BaseSite):
         if not searchstring:
             raise Error("search: searchstring cannot be empty")
         if where not in where_types:
-            raise Error("search: unrecognized 'where' value: %s" % where)
+            raise Error("search: unrecognized 'where' value: {0!s}".format(where))
         if where in ('title', 'titles'):
             if isinstance(self.family, WikimediaFamily):
                 # 'title' search was disabled, use intitle instead
@@ -4802,11 +4777,9 @@ class APISite(BaseSite):
 
         if text_overrides:
             if 'text' in kwargs:
-                raise ValueError('text can not be used with any of %s'
-                                 % ', '.join(text_overrides))
+                raise ValueError('text can not be used with any of {0!s}'.format(', '.join(text_overrides)))
             if len(text_overrides) > 1:
-                raise ValueError('Multiple text overrides used: %s'
-                                 % ', '.join(text_overrides))
+                raise ValueError('Multiple text overrides used: {0!s}'.format(', '.join(text_overrides)))
             text = None
             basetimestamp = False
         elif 'text' in kwargs:
@@ -4855,20 +4828,18 @@ class APISite(BaseSite):
                 params['watchlist'] = watch
         elif watch:
             pywikibot.warning(
-                u"editpage: Invalid watch value '%(watch)s' ignored."
-                % {'watch': watch})
+                u"editpage: Invalid watch value '{watch!s}' ignored.".format(**{'watch': watch}))
         req = self._simple_request(**params)
         while True:
             try:
                 result = req.submit()
-                pywikibot.debug(u"editpage response: %s" % result,
+                pywikibot.debug(u"editpage response: {0!s}".format(result),
                                 _logger)
             except api.APIError as err:
                 self.unlock_page(page)
                 if err.code.endswith("anon") and self.logged_in():
                     pywikibot.debug(
-                        u"editpage: received '%s' even though bot is logged in"
-                        % err.code,
+                        u"editpage: received '{0!s}' even though bot is logged in".format(err.code),
                         _logger)
                 if err.code in self._ep_errors:
                     if isinstance(self._ep_errors[err.code], basestring):
@@ -4882,8 +4853,7 @@ class APISite(BaseSite):
                     else:
                         raise self._ep_errors[err.code](page)
                 pywikibot.debug(
-                    u"editpage: Unexpected error code '%s' received."
-                    % err.code,
+                    u"editpage: Unexpected error code '{0!s}' received.".format(err.code),
                     _logger)
                 raise
             assert "edit" in result and "result" in result["edit"], result
@@ -4891,8 +4861,7 @@ class APISite(BaseSite):
                 self.unlock_page(page)
                 if "nochange" in result["edit"]:
                     # null edit, page not changed
-                    pywikibot.log(u"Page [[%s]] saved without any changes."
-                                  % page.title())
+                    pywikibot.log(u"Page [[{0!s}]] saved without any changes.".format(page.title()))
                     return True
                 page.latest_revision_id = result["edit"]["newrevid"]
                 # see https://www.mediawiki.org/wiki/API:Wikimania_2006_API_discussion#Notes
@@ -4909,8 +4878,7 @@ class APISite(BaseSite):
                         continue
                     elif "url" in captcha:
                         import webbrowser
-                        webbrowser.open('%s://%s%s'
-                                        % (self.protocol(),
+                        webbrowser.open('{0!s}://{1!s}{2!s}'.format(self.protocol(),
                                            self.hostname(),
                                            captcha["url"]))
                         req['captchaword'] = pywikibot.input(
@@ -4929,13 +4897,11 @@ class APISite(BaseSite):
                 elif 'code' in result['edit'] and 'info' in result['edit']:
                     self.unlock_page(page)
                     pywikibot.error(
-                        u"editpage: %s\n%s, "
-                        % (result['edit']['code'], result['edit']['info']))
+                        u"editpage: {0!s}\n{1!s}, ".format(result['edit']['code'], result['edit']['info']))
                     return False
                 else:
                     self.unlock_page(page)
-                    pywikibot.error(u"editpage: unknown failure reason %s"
-                                    % str(result))
+                    pywikibot.error(u"editpage: unknown failure reason {0!s}".format(str(result)))
                     return False
             else:
                 self.unlock_page(page)
@@ -4997,8 +4963,7 @@ class APISite(BaseSite):
         else:
             newtitle = newlink.title
         if oldtitle == newtitle:
-            raise Error("Cannot move page %s to its own title."
-                        % oldtitle)
+            raise Error("Cannot move page {0!s} to its own title.".format(oldtitle))
         if not page.exists():
             raise NoPage(page,
                          "Cannot move page %(page)s because it "
@@ -5014,13 +4979,12 @@ class APISite(BaseSite):
         req['from'] = oldtitle  # "from" is a python keyword
         try:
             result = req.submit()
-            pywikibot.debug(u"movepage response: %s" % result,
+            pywikibot.debug(u"movepage response: {0!s}".format(result),
                             _logger)
         except api.APIError as err:
             if err.code.endswith("anon") and self.logged_in():
                 pywikibot.debug(
-                    u"movepage: received '%s' even though bot is logged in"
-                    % err.code,
+                    u"movepage: received '{0!s}' even though bot is logged in".format(err.code),
                     _logger)
             if err.code in self._mv_errors:
                 on_error = self._mv_errors[err.code]
@@ -5050,20 +5014,18 @@ class APISite(BaseSite):
                         'user': self.user(),
                     }
                     raise Error(on_error % errdata)
-            pywikibot.debug(u"movepage: Unexpected error code '%s' received."
-                            % err.code,
+            pywikibot.debug(u"movepage: Unexpected error code '{0!s}' received.".format(err.code),
                             _logger)
             raise
         finally:
             self.unlock_page(page)
         if "move" not in result:
-            pywikibot.error(u"movepage: %s" % result)
+            pywikibot.error(u"movepage: {0!s}".format(result))
             raise Error("movepage: unexpected response")
         # TODO: Check for talkmove-error messages
         if "talkmove-error-code" in result["move"]:
             pywikibot.warning(
-                u"movepage: Talk page %s not moved"
-                % (page.toggleTalkPage().title(asLink=True)))
+                u"movepage: Talk page {0!s} not moved".format((page.toggleTalkPage().title(asLink=True))))
         return pywikibot.Page(page, newtitle)
 
     # catalog of rollback errors for use in error messages
@@ -5088,8 +5050,7 @@ class APISite(BaseSite):
         """
         if len(page._revisions) < 2:
             raise Error(
-                u"Rollback of %s aborted; load revision history first."
-                % page.title(asLink=True))
+                u"Rollback of {0!s} aborted; load revision history first.".format(page.title(asLink=True)))
         last_rev = page.latest_revision
         last_user = last_rev.user
         for rev in sorted(page._revisions.values(), reverse=True,
@@ -5099,8 +5060,7 @@ class APISite(BaseSite):
                 break
         else:
             raise Error(
-                u"Rollback of %s aborted; only one user in revision history."
-                % page.title(asLink=True))
+                u"Rollback of {0!s} aborted; only one user in revision history.".format(page.title(asLink=True)))
         parameters = merge_unique_dicts(kwargs, action='rollback',
                                         title=page,
                                         token=self.tokens['rollback'],
@@ -5117,8 +5077,7 @@ class APISite(BaseSite):
             }
             if err.code in self._rb_errors:
                 raise Error(self._rb_errors[err.code] % errdata)
-            pywikibot.debug(u"rollback: Unexpected error code '%s' received."
-                            % err.code,
+            pywikibot.debug(u"rollback: Unexpected error code '{0!s}' received.".format(err.code),
                             _logger)
             raise
         finally:
@@ -5162,8 +5121,7 @@ class APISite(BaseSite):
             }
             if err.code in self._dl_errors:
                 raise Error(self._dl_errors[err.code] % errdata)
-            pywikibot.debug(u"delete: Unexpected error code '%s' received."
-                            % err.code,
+            pywikibot.debug(u"delete: Unexpected error code '{0!s}' received.".format(err.code),
                             _logger)
             raise
         else:
@@ -5202,8 +5160,7 @@ class APISite(BaseSite):
             }
             if err.code in self._dl_errors:
                 raise Error(self._dl_errors[err.code] % errdata)
-            pywikibot.debug(u"delete: Unexpected error code '%s' received."
-                            % err.code,
+            pywikibot.debug(u"delete: Unexpected error code '{0!s}' received.".format(err.code),
                             _logger)
             raise
         finally:
@@ -5277,8 +5234,7 @@ class APISite(BaseSite):
             }
             if err.code in self._protect_errors:
                 raise Error(self._protect_errors[err.code] % errdata)
-            pywikibot.debug(u"protect: Unexpected error code '%s' received."
-                            % err.code,
+            pywikibot.debug(u"protect: Unexpected error code '{0!s}' received.".format(err.code),
                             _logger)
             raise
         else:
@@ -5383,8 +5339,7 @@ class APISite(BaseSite):
                 errdata[idtype] = idvalue
                 if err.code in self._patrol_errors:
                     raise Error(self._patrol_errors[err.code] % errdata)
-                pywikibot.debug(u"protect: Unexpected error code '%s' received."
-                                % err.code,
+                pywikibot.debug(u"protect: Unexpected error code '{0!s}' received.".format(err.code),
                                 _logger)
                 raise
 
@@ -5520,7 +5475,7 @@ class APISite(BaseSite):
         req = self._simple_request(**parameters)
         result = req.submit()
         if "watch" not in result:
-            pywikibot.error(u"watchpage: Unexpected API response:\n%s" % result)
+            pywikibot.error(u"watchpage: Unexpected API response:\n{0!s}".format(result))
             return False
         return ('unwatched' if unwatch else 'watched') in result["watch"]
 
@@ -5544,7 +5499,7 @@ class APISite(BaseSite):
                 linkupdate = True
         result = req.submit()
         if 'purge' not in result:
-            pywikibot.error(u'purgepages: Unexpected API response:\n%s' % result)
+            pywikibot.error(u'purgepages: Unexpected API response:\n{0!s}'.format(result))
             return False
         result = result['purge']
         purged = ['purged' in page for page in result]
@@ -5717,8 +5672,7 @@ class APISite(BaseSite):
         # check for required user right
         if "upload" not in self.userinfo["rights"]:
             raise Error(
-                "User '%s' does not have upload rights on site %s."
-                % (self.user(), self))
+                "User '{0!s}' does not have upload rights on site {1!s}.".format(self.user(), self))
         # check for required parameters
         if bool(source_filename) == bool(source_url):
             raise ValueError("APISite.upload: must provide either "
@@ -5758,8 +5712,7 @@ class APISite(BaseSite):
             if os.path.isfile(source_filename):
                 file_size = os.path.getsize(source_filename)
             elif offset is not False:
-                raise ValueError("File '%s' does not exist."
-                                 % source_filename)
+                raise ValueError("File '{0!s}' does not exist.".format(source_filename))
 
         if source_filename and _file_key:
             assert offset is False or file_size is not None
@@ -5920,8 +5873,7 @@ class APISite(BaseSite):
             # upload by URL
             if "upload_by_url" not in self.userinfo["rights"]:
                 raise Error(
-                    "User '%s' is not authorized to upload by URL on site %s."
-                    % (self.user(), self))
+                    "User '{0!s}' is not authorized to upload by URL on site {1!s}.".format(self.user(), self))
             final_request = self._simple_request(
                 action='upload', filename=file_page_title,
                 url=source_url, comment=comment, text=text, token=token)
@@ -5974,7 +5926,7 @@ class APISite(BaseSite):
                                     file_key=_file_key,
                                     offset=result.get('offset', False))
         elif "result" not in result:
-            pywikibot.output(u"Upload: unrecognized response: %s" % result)
+            pywikibot.output(u"Upload: unrecognized response: {0!s}".format(result))
         if result["result"] == "Success":
             if report_success:
                 pywikibot.output(u"Upload successful.")
@@ -6794,8 +6746,7 @@ class DataSite(APISite):
             return self._item_namespace
         else:
             raise EntityTypeUnknownException(
-                '%r does not support entity type "item"'
-                % self)
+                '{0!r} does not support entity type "item"'.format(self))
 
     @property
     def property_namespace(self):
@@ -6812,8 +6763,7 @@ class DataSite(APISite):
             return self._property_namespace
         else:
             raise EntityTypeUnknownException(
-                '%r does not support entity type "property"'
-                % self)
+                '{0!r} does not support entity type "property"'.format(self))
 
     def _get_baserevid(self, claim, baserevid):
         """Check that claim.on_item is set and matches baserevid if used."""
@@ -6871,7 +6821,7 @@ class DataSite(APISite):
             props = 'sitelinks'
 
         assert props in wbdata, \
-            "API wbgetentities response lacks %s key" % props
+            "API wbgetentities response lacks {0!s} key".format(props)
         return wbdata[props]
 
     @deprecated("pywikibot.WikibasePage")
@@ -6901,7 +6851,7 @@ class DataSite(APISite):
                 ids = ids.upper()
 
             assert ids in wbdata['entities'], \
-                "API wbgetentities response lacks %s key" % ids
+                "API wbgetentities response lacks {0!s} key".format(ids)
 
             return wbdata['entities'][ids]
         else:

--- a/pywikibot/site_detect.py
+++ b/pywikibot/site_detect.py
@@ -112,7 +112,7 @@ class MWSite(object):
             "?action=query&meta=siteinfo&siprop=interwikimap&sifilteriw=local&format=json")
         iw = json.loads(response.content)
         if 'error' in iw:
-            raise RuntimeError('%s - %s' % (iw['error']['code'],
+            raise RuntimeError('{0!s} - {1!s}'.format(iw['error']['code'],
                                             iw['error']['info']))
         return [wiki for wiki in iw['query']['interwikimap']
                 if u'language' in wiki]
@@ -121,8 +121,7 @@ class MWSite(object):
         """Parse HTML."""
         if not self.REwgEnableApi.search(data):
             pywikibot.log(
-                'wgEnableApi is not enabled in HTML of %s'
-                % self.fromurl)
+                'wgEnableApi is not enabled in HTML of {0!s}'.format(self.fromurl))
         try:
             self.version = MediaWikiVersion(
                 self.REwgVersion.search(data).group(1))

--- a/pywikibot/textlib.py
+++ b/pywikibot/textlib.py
@@ -142,7 +142,7 @@ def to_local_digits(phrase, lang):
     digits = NON_LATIN_DIGITS.get(lang)
     if not digits:
         return phrase
-    phrase = u"%s" % phrase
+    phrase = u"{0!s}".format(phrase)
     for i in range(10):
         phrase = phrase.replace(str(i), digits[i])
     return phrase
@@ -280,8 +280,7 @@ def _get_regexes(keys, site):
                 # nowiki, noinclude, includeonly, timeline, math ond other
                 # extensions
                 if exc not in _regex_cache:
-                    _regex_cache[exc] = re.compile(r'(?is)<%s>.*?</%s>'
-                                                   % (exc, exc))
+                    _regex_cache[exc] = re.compile(r'(?is)<{0!s}>.*?</{1!s}>'.format(exc, exc))
                 result.append(_regex_cache[exc])
             # handle alias
             if exc == 'source':
@@ -390,8 +389,8 @@ def replaceExcept(text, old, new, exceptions, caseInsensitive=False,
                         replacement += new[last:group_match.start()]
                         replacement += match.group(group_id) or ''
                     except IndexError:
-                        pywikibot.output('\nInvalid group reference: %s' % group_id)
-                        pywikibot.output('Groups found:\n%s' % match.groups())
+                        pywikibot.output('\nInvalid group reference: {0!s}'.format(group_id))
+                        pywikibot.output('Groups found:\n{0!s}'.format(match.groups()))
                         raise IndexError
                     last = group_match.end()
                 replacement += new[last:]
@@ -482,11 +481,11 @@ class _GetDataHTML(HTMLParser):
 
     def handle_starttag(self, tag, attrs):
         if tag in self.keeptags:
-            self.textdata += u"<%s>" % tag
+            self.textdata += u"<{0!s}>".format(tag)
 
     def handle_endtag(self, tag):
         if tag in self.keeptags:
-            self.textdata += u"</%s>" % tag
+            self.textdata += u"</{0!s}>".format(tag)
 
 
 def isDisabled(text, index, tags=None):
@@ -885,8 +884,7 @@ def removeLanguageLinks(text, site=None, marker=''):
                          list(site.family.obsolete.keys()))
     if not languages:
         return text
-    interwikiR = re.compile(r'\[\[(%s)\s?:[^\[\]\n]*\]\][\s]*'
-                            % languages, re.IGNORECASE)
+    interwikiR = re.compile(r'\[\[({0!s})\s?:[^\[\]\n]*\]\][\s]*'.format(languages), re.IGNORECASE)
     text = replaceExcept(text, interwikiR, '',
                          ['nowiki', 'comment', 'math', 'pre', 'source'],
                          marker=marker,
@@ -985,15 +983,15 @@ def replaceLanguageLinks(oldtext, new, site=None, addOnly=False,
                     # Do we have a noinclude at the end of the template?
                     parts = s2.split(includeOff)
                     lastpart = parts[-1]
-                    if re.match(r'\s*%s' % marker, lastpart):
+                    if re.match(r'\s*{0!s}'.format(marker), lastpart):
                         # Put the langlinks back into the noinclude's
-                        regexp = re.compile(r'%s\s*%s' % (includeOff, marker))
+                        regexp = re.compile(r'{0!s}\s*{1!s}'.format(includeOff, marker))
                         newtext = regexp.sub(s + includeOff, s2)
                     else:
                         # Put the langlinks at the end, inside noinclude's
                         newtext = (s2.replace(marker, '').strip() +
                                    separator +
-                                   u'%s\n%s%s\n' % (includeOn, s, includeOff)
+                                   u'{0!s}\n{1!s}{2!s}\n'.format(includeOn, s, includeOff)
                                    )
                 else:
                     newtext = s2.replace(marker, '').strip() + separator + s
@@ -1086,8 +1084,7 @@ def getCategoryLinks(text, site=None, include=None, expand_text=False):
     # and HTML comments
     text = removeDisabledParts(text, include=include)
     catNamespace = '|'.join(site.namespaces.CATEGORY)
-    R = re.compile(r'\[\[\s*(?P<namespace>%s)\s*:\s*(?P<rest>.+?)\]\]'
-                   % catNamespace, re.I)
+    R = re.compile(r'\[\[\s*(?P<namespace>{0!s})\s*:\s*(?P<rest>.+?)\]\]'.format(catNamespace), re.I)
     for match in R.finditer(text):
         if expand_text and '{{' in match.group('rest'):
             rest = site.expand_text(match.group('rest'))
@@ -1098,7 +1095,7 @@ def getCategoryLinks(text, site=None, include=None, expand_text=False):
         else:
             title, sortKey = rest, None
         cat = pywikibot.Category(pywikibot.Link(
-                                 '%s:%s' % (match.group('namespace'), title),
+                                 '{0!s}:{1!s}'.format(match.group('namespace'), title),
                                  site),
                                  sortKey=sortKey)
         result.append(cat)
@@ -1118,14 +1115,14 @@ def removeCategoryLinks(text, site=None, marker=''):
     if site is None:
         site = pywikibot.Site()
     catNamespace = '|'.join(site.namespaces.CATEGORY)
-    categoryR = re.compile(r'\[\[\s*(%s)\s*:.*?\]\]\s*' % catNamespace, re.I)
+    categoryR = re.compile(r'\[\[\s*({0!s})\s*:.*?\]\]\s*'.format(catNamespace), re.I)
     text = replaceExcept(text, categoryR, '',
                          ['nowiki', 'comment', 'math', 'pre', 'source', 'includeonly'],
                          marker=marker,
                          site=site)
     if marker:
         # avoid having multiple linefeeds at the end of the text
-        text = re.sub(r'\s*%s' % re.escape(marker), config.LS + marker,
+        text = re.sub(r'\s*{0!s}'.format(re.escape(marker)), config.LS + marker,
                       text.strip())
     return text.strip()
 
@@ -1170,14 +1167,12 @@ def replaceCategoryInPlace(oldtext, oldcat, newcat, site=None):
     title = re.escape(title)
     # title might not be capitalized correctly on the wiki
     if title[0].isalpha() and site.namespaces[14].case == 'first-letter':
-        title = "[%s%s]" % (title[0].upper(), title[0].lower()) + title[1:]
+        title = "[{0!s}{1!s}]".format(title[0].upper(), title[0].lower()) + title[1:]
     # spaces and underscores in page titles are interchangeable and collapsible
     title = title.replace(r"\ ", "[ _]+").replace(r"\_", "[ _]+")
-    categoryR = re.compile(r'\[\[\s*(%s)\s*:\s*%s\s*((?:\|[^]]+)?\]\])'
-                           % (catNamespace, title), re.I)
+    categoryR = re.compile(r'\[\[\s*({0!s})\s*:\s*{1!s}\s*((?:\|[^]]+)?\]\])'.format(catNamespace, title), re.I)
     categoryRN = re.compile(
-        r'^[^\S\n]*\[\[\s*(%s)\s*:\s*%s\s*((?:\|[^]]+)?\]\])[^\S\n]*\n'
-        % (catNamespace, title), re.I | re.M)
+        r'^[^\S\n]*\[\[\s*({0!s})\s*:\s*{1!s}\s*((?:\|[^]]+)?\]\])[^\S\n]*\n'.format(catNamespace, title), re.I | re.M)
     if newcat is None:
         # First go through and try the more restrictive regex that removes
         # an entire line, if the category is the only thing on that line (this
@@ -1190,7 +1185,7 @@ def replaceCategoryInPlace(oldtext, oldcat, newcat, site=None):
                              site=site)
     else:
         text = replaceExcept(oldtext, categoryR,
-                             '[[%s:%s\\2' % (site.namespace(14),
+                             '[[{0!s}:{1!s}\\2'.format(site.namespace(14),
                                              newcat.title(withNamespace=False)),
                              ['nowiki', 'comment', 'math', 'pre', 'source'],
                              site=site)
@@ -1476,10 +1471,10 @@ def extract_templates_and_params_regex(text, remove_disabled_parts=True,
     result = []
     Rmath = re.compile(r'<math>[^<]+</math>')
     Rvalue = re.compile(r'{{{.+?}}}')
-    Rmarker1 = re.compile(r'%s(\d+)%s' % (marker1, marker1))
-    Rmarker2 = re.compile(r'%s(\d+)%s' % (marker2, marker2))
-    Rmarker3 = re.compile(r'%s(\d+)%s' % (marker3, marker3))
-    Rmarker4 = re.compile(r'%s(\d+)%s' % (marker4, marker4))
+    Rmarker1 = re.compile(r'{0!s}(\d+){1!s}'.format(marker1, marker1))
+    Rmarker2 = re.compile(r'{0!s}(\d+){1!s}'.format(marker2, marker2))
+    Rmarker3 = re.compile(r'{0!s}(\d+){1!s}'.format(marker3, marker3))
+    Rmarker4 = re.compile(r'{0!s}(\d+){1!s}'.format(marker4, marker4))
 
     # Replace math with markers
     maths = {}
@@ -1487,7 +1482,7 @@ def extract_templates_and_params_regex(text, remove_disabled_parts=True,
     for m in Rmath.finditer(thistxt):
         count += 1
         item = m.group()
-        thistxt = thistxt.replace(item, '%s%d%s' % (marker3, count, marker3))
+        thistxt = thistxt.replace(item, '{0!s}{1:d}{2!s}'.format(marker3, count, marker3))
         maths[count] = item
 
     values = {}
@@ -1496,10 +1491,10 @@ def extract_templates_and_params_regex(text, remove_disabled_parts=True,
         count += 1
         # If we have digits between brackets, restoring from dict may fail.
         # So we need to change the index. We have to search in the origin text.
-        while u'}}}%d{{{' % count in text:
+        while u'}}}}}}{0:d}{{{{{{'.format(count) in text:
             count += 1
         item = m.group()
-        thistxt = thistxt.replace(item, '%s%d%s' % (marker4, count, marker4))
+        thistxt = thistxt.replace(item, '{0!s}{1:d}{2!s}'.format(marker4, count, marker4))
         values[count] = item
 
     inside = {}
@@ -1513,10 +1508,10 @@ def extract_templates_and_params_regex(text, remove_disabled_parts=True,
                 continue  # speed up
             seen.add(item)
             count += 1
-            while u'}}%d{{' % count in text:
+            while u'}}}}{0:d}{{{{'.format(count) in text:
                 count += 1
             thistxt = thistxt.replace(item,
-                                      '%s%d%s' % (marker1, count, marker1))
+                                      '{0!s}{1:d}{2!s}'.format(marker1, count, marker1))
 
             # Make sure stored templates don't contain markers
             for m2 in Rmarker1.finditer(item):
@@ -1576,7 +1571,7 @@ def extract_templates_and_params_regex(text, remove_disabled_parts=True,
                     count2 += 1
                     item = m2.group(0)
                     paramString = paramString.replace(
-                        item, '%s%d%s' % (marker2, count2, marker2))
+                        item, '{0!s}{1:d}{2!s}'.format(marker2, count2, marker2))
                     links[count2] = item
                 # Parse string
                 markedParams = paramString.split('|')
@@ -1670,9 +1665,9 @@ def glue_template_and_params(template_and_params):
     (template, params) = template_and_params
     text = u''
     for item in params:
-        text += u'|%s=%s\n' % (item, params[item])
+        text += u'|{0!s}={1!s}\n'.format(item, params[item])
 
-    return u'{{%s\n%s}}' % (template, text)
+    return u'{{{{{0!s}\n{1!s}}}}}'.format(template, text)
 
 
 # --------------------------
@@ -1700,7 +1695,7 @@ def does_text_contain_section(pagetext, section):
     section = re.sub(r'\\\[\\\[(\\:)?', r'\[\[\:?', re.escape(section))
     # match underscores and white spaces
     section = re.sub(r'\\?[ _]', '[ _]', section)
-    m = re.search("=+[ ']*%s[ ']*=+" % section, pagetext)
+    m = re.search("=+[ ']*{0!s}[ ']*=+".format(section), pagetext)
     return bool(m)
 
 
@@ -1751,7 +1746,7 @@ class tzoneFixedOffset(datetime.tzinfo):
 
     def __repr__(self):
         """Return the internal representation of the timezone."""
-        return "%s(%s, %s)" % (
+        return "{0!s}({1!s}, {2!s})".format(
             self.__class__.__name__,
             self.__offset.days * 86400 + self.__offset.seconds,
             self.__name
@@ -1782,7 +1777,7 @@ class TimeStripper(object):
 
         timeR = r'(?P<time>(?P<hour>([0-1]\d|2[0-3]))[:\.h](?P<minute>[0-5]\d))'
         timeznR = r'\((?P<tzinfo>[A-Z]+)\)'
-        yearR = r'(?P<year>(19|20)\d\d)(?:%s)?' % u'\ub144'
+        yearR = r'(?P<year>(19|20)\d\d)(?:{0!s})?'.format(u'\ub144')
         # if months have 'digits' as names, they need to be
         # removed; will be handled as digits in regex, adding d+{1,2}\.?
         escaped_months = [_ for _ in self.origNames2monthNum if
@@ -1795,12 +1790,11 @@ class TimeStripper(object):
         # the last one is workaround for Korean
         if any(_.isdigit() for _ in self.origNames2monthNum):
             self.is_digit_month = True
-            monthR = r'(?P<month>(%s)|(?:1[012]|0?[1-9])\.)' \
-                % u'|'.join(escaped_months)
-            dayR = r'(?P<day>(3[01]|[12]\d|0?[1-9]))(?:%s)?\.?\s*(?:[01]?\d\.)?' % u'\uc77c'
+            monthR = r'(?P<month>({0!s})|(?:1[012]|0?[1-9])\.)'.format(u'|'.join(escaped_months))
+            dayR = r'(?P<day>(3[01]|[12]\d|0?[1-9]))(?:{0!s})?\.?\s*(?:[01]?\d\.)?'.format(u'\uc77c')
         else:
             self.is_digit_month = False
-            monthR = r'(?P<month>(%s))' % u'|'.join(escaped_months)
+            monthR = r'(?P<month>({0!s}))'.format(u'|'.join(escaped_months))
             dayR = r'(?P<day>(3[01]|[12]\d|0?[1-9]))\.?'
 
         self.ptimeR = re.compile(timeR)
@@ -1907,8 +1901,7 @@ class TimeStripper(object):
             try:
                 dateDict['month'] = self.origNames2monthNum[dateDict['month']]
             except KeyError:
-                pywikibot.output(u'incorrect month name "%s" in page in site %s'
-                                 % (dateDict['month'], self.site))
+                pywikibot.output(u'incorrect month name "{0!s}" in page in site {1!s}'.format(dateDict['month'], self.site))
                 raise KeyError
 
             # convert to integers
@@ -1918,8 +1911,7 @@ class TimeStripper(object):
                 try:
                     dateDict[k] = int(v)
                 except ValueError:
-                    raise ValueError('Value: %s could not be converted for key: %s.'
-                                     % (v, k))
+                    raise ValueError('Value: {0!s} could not be converted for key: {1!s}.'.format(v, k))
 
             # find timezone
             dateDict['tzinfo'] = self.tzinfo

--- a/pywikibot/throttle.py
+++ b/pywikibot/throttle.py
@@ -80,7 +80,7 @@ class Throttle(object):
         global pid
         self.lock.acquire()
         mysite = self.mysite
-        pywikibot.debug(u"Checking multiplicity: pid = %(pid)s" % globals(),
+        pywikibot.debug(u"Checking multiplicity: pid = {pid!s}".format(**globals()),
                         _logger)
         try:
             processes = []
@@ -130,7 +130,7 @@ class Throttle(object):
             try:
                 f = open(self.ctrlfilename, 'w')
                 for p in processes:
-                    f.write("%(pid)s %(time)s %(site)s\n" % p)
+                    f.write("{pid!s} {time!s} {site!s}\n".format(**p))
             except IOError:
                 pass
             else:
@@ -227,7 +227,7 @@ class Throttle(object):
         try:
             f = open(self.ctrlfilename, 'w')
             for p in processes:
-                f.write("%(pid)s %(time)s %(site)s\n" % p)
+                f.write("{pid!s} {time!s} {site!s}\n".format(**p))
         except IOError:
             return
         f.close()
@@ -241,11 +241,11 @@ class Throttle(object):
         if seconds <= 0:
             return
 
-        message = (u"Sleeping for %(seconds).1f seconds, %(now)s" % {
+        message = (u"Sleeping for {seconds:.1f} seconds, {now!s}".format(**{
             'seconds': seconds,
             'now': time.strftime("%Y-%m-%d %H:%M:%S",
                                  time.localtime())
-        })
+        }))
         if seconds > config.noisysleep:
             pywikibot.output(message)
         else:

--- a/pywikibot/titletranslate.py
+++ b/pywikibot/titletranslate.py
@@ -82,8 +82,7 @@ def translate(page=None, hints=None, auto=True, removebrackets=False,
                         result.add(x)
                 else:
                     if config.verbose_output:
-                        pywikibot.output(u"Ignoring unknown language code %s"
-                                         % newcode)
+                        pywikibot.output(u"Ignoring unknown language code {0!s}".format(newcode))
 
     # Autotranslate dates into all other languages, the rest will come from
     # existing interwiki links.
@@ -94,8 +93,7 @@ def translate(page=None, hints=None, auto=True, removebrackets=False,
         if dictName:
             if True:
                 pywikibot.output(
-                    u'TitleTranslate: %s was recognized as %s with value %d'
-                    % (page.title(), dictName, value))
+                    u'TitleTranslate: {0!s} was recognized as {1!s} with value {2:d}'.format(page.title(), dictName, value))
                 for entryLang, entry in date.formats[dictName].items():
                     if entryLang not in site.languages():
                         continue

--- a/pywikibot/tools/__init__.py
+++ b/pywikibot/tools/__init__.py
@@ -95,7 +95,7 @@ class NotImplementedClass(object):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         raise NotImplementedError(
-            '%s: %s' % (self.__class__.__name__, self.__doc__))
+            '{0!s}: {1!s}'.format(self.__class__.__name__, self.__doc__))
 
 
 if PYTHON_VERSION < (2, 7):
@@ -347,10 +347,9 @@ class LazyRegex(object):
             if hasattr(self._compiled, attr):
                 return getattr(self._compiled, attr)
 
-            raise AttributeError('%s: attr %s not recognised'
-                                 % (self.__class__.__name__, attr))
+            raise AttributeError('{0!s}: attr {1!s} not recognised'.format(self.__class__.__name__, attr))
         else:
-            raise AttributeError('%s.raw not set' % self.__class__.__name__)
+            raise AttributeError('{0!s}.raw not set'.format(self.__class__.__name__))
 
 
 class DeprecatedRegex(LazyRegex):
@@ -636,7 +635,7 @@ class ThreadList(list):
         super(ThreadList, self).__init__(*args)
         for item in self:
             if not isinstance(threading.Thread, item):
-                raise TypeError("Cannot add '%s' to ThreadList" % type(item))
+                raise TypeError("Cannot add '{0!s}' to ThreadList".format(type(item)))
 
     def active_count(self):
         """Return the number of alive threads, and delete all non-alive ones."""
@@ -651,22 +650,21 @@ class ThreadList(list):
     def append(self, thd):
         """Add a thread to the pool and start it."""
         if not isinstance(thd, threading.Thread):
-            raise TypeError("Cannot append '%s' to ThreadList" % type(thd))
+            raise TypeError("Cannot append '{0!s}' to ThreadList".format(type(thd)))
         while self.active_count() >= self.limit:
             time.sleep(2)
         super(ThreadList, self).append(thd)
         thd.start()
-        debug("thread %d ('%s') started" % (len(self), type(thd)),
+        debug("thread {0:d} ('{1!s}') started".format(len(self), type(thd)),
               self._logger)
 
     def stop_all(self):
         """Stop all threads the pool."""
         if self:
-            debug(u'EARLY QUIT: Threads: %d' % len(self), self._logger)
+            debug(u'EARLY QUIT: Threads: {0:d}'.format(len(self)), self._logger)
         for thd in self:
             thd.stop()
-            debug(u'EARLY QUIT: Queue size left in %s: %s'
-                  % (thd, thd.queue.qsize()), self._logger)
+            debug(u'EARLY QUIT: Queue size left in {0!s}: {1!s}'.format(thd, thd.queue.qsize()), self._logger)
 
 
 def intersect_generators(genlist):
@@ -1363,8 +1361,7 @@ def deprecated_args(**arg_pairs):
                             cls = PendingDeprecationWarning
                         else:
                             cls = DeprecationWarning
-                        warn(u"%(old_arg)s argument of %(name)s is deprecated."
-                             % output_args,
+                        warn(u"{old_arg!s} argument of {name!s} is deprecated.".format(**output_args),
                              cls, depth)
                     del __kw[old_arg]
             return obj(*__args, **__kw)

--- a/pywikibot/tools/_logging.py
+++ b/pywikibot/tools/_logging.py
@@ -46,13 +46,13 @@ class RotatingFileHandler(logging.handlers.RotatingFileHandler):
         root, ext = os.path.splitext(self.baseFilename)
         if self.backupCount > 0:
             for i in range(self.backupCount - 1, 0, -1):
-                sfn = "%s.%d%s" % (root, i, ext)
-                dfn = "%s.%d%s" % (root, i + 1, ext)
+                sfn = "{0!s}.{1:d}{2!s}".format(root, i, ext)
+                dfn = "{0!s}.{1:d}{2!s}".format(root, i + 1, ext)
                 if os.path.exists(sfn):
                     if os.path.exists(dfn):
                         os.remove(dfn)
                     os.rename(sfn, dfn)
-            dfn = "%s.1%s" % (root, ext)
+            dfn = "{0!s}.1{1!s}".format(root, ext)
             if os.path.exists(dfn):
                 os.remove(dfn)
             os.rename(self.baseFilename, dfn)
@@ -60,7 +60,7 @@ class RotatingFileHandler(logging.handlers.RotatingFileHandler):
             if not hasattr(self, '_lastNo'):
                 self._lastNo = 1
             while True:
-                fn = "%s.%d%s" % (root, self._lastNo, ext)
+                fn = "{0!s}.{1:d}{2!s}".format(root, self._lastNo, ext)
                 self._lastNo += 1
                 if not os.path.exists(fn):
                     break

--- a/pywikibot/tools/djvu.py
+++ b/pywikibot/tools/djvu.py
@@ -47,7 +47,7 @@ class DjVuFile(object):
                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (stdoutdata, stderrdata) = dp.communicate()
             if dp.returncode != 0:
-                error('djvulibre library error!\n%s' % stderrdata)
+                error('djvulibre library error!\n{0!s}'.format(stderrdata))
             self._image_count = int(stdoutdata)
         return self._image_count
 
@@ -58,7 +58,7 @@ class DjVuFile(object):
                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (stdoutdata, stderrdata) = dp.communicate()
             if dp.returncode != 0:
-                error('djvulibre library error!\n%s' % stderrdata)
+                error('djvulibre library error!\n{0!s}'.format(stderrdata))
             txt = stdoutdata.decode('utf-8')
             self._has_text = 'TXTz' in txt
         return self._has_text
@@ -82,14 +82,14 @@ class DjVuFile(object):
     def get_page(self, n):
         """Get page n for djvu file."""
         if not self.has_text():
-            raise ValueError('Djvu file %s has no text layer.' % self.file_djvu)
+            raise ValueError('Djvu file {0!s} has no text layer.'.format(self.file_djvu))
         if not (1 <= n <= self.number_of_images()):
             raise ValueError('Requested page number %d is not in file %s'
                              ' page range [%d-%d]'
                              % (n, self.file_djvu, 1, self.number_of_images()))
-        dp = subprocess.Popen(['djvutxt', '--page=%d' % n, self.file_djvu],
+        dp = subprocess.Popen(['djvutxt', '--page={0:d}'.format(n), self.file_djvu],
                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdoutdata, stderrdata) = dp.communicate()
         if dp.returncode != 0:
-            error('djvulibre library error!\n%s' % stderrdata)
+            error('djvulibre library error!\n{0!s}'.format(stderrdata))
         return self._remove_control_chars(stdoutdata)

--- a/pywikibot/tools/ip.py
+++ b/pywikibot/tools/ip.py
@@ -35,7 +35,7 @@ if not ip_address or sys.version_info[0] < 3:
         if _ipaddr_version >= StrictVersion('2.1.10'):
             from ipaddr import IPAddress as ip_address
         else:
-            _ipaddr_e = ImportError('ipaddr %s is broken.' % _ipaddr_version)
+            _ipaddr_e = ImportError('ipaddr {0!s} is broken.'.format(_ipaddr_version))
 
 if ip_address and ip_address.__module__ == 'ipaddress':
     if sys.version_info[0] < 3:

--- a/pywikibot/userinterfaces/gui.py
+++ b/pywikibot/userinterfaces/gui.py
@@ -224,7 +224,7 @@ class TextEditor(ScrolledText):
                     if not idx:
                         break
                     # index right after the end of the occurrence
-                    lastidx = '%s+%dc' % (idx, len(s))
+                    lastidx = '{0!s}+{1:d}c'.format(idx, len(s))
                     # tag the whole occurrence (start included, stop excluded)
                     self.tag_add('found', idx, lastidx)
                     # prepare to search for next occurrence
@@ -251,7 +251,7 @@ class TextEditor(ScrolledText):
         if lineno <= 0:
             self.bell()
             return "break"
-        self.mark_set("insert", "%d.0" % lineno)
+        self.mark_set("insert", "{0:d}.0".format(lineno))
         self.see("insert")
 
 
@@ -383,7 +383,7 @@ class EditBoxWindow(Tkinter.Frame):
             column = jumpIndex - (text[:jumpIndex].rfind('\n') + 1)
             # don't know how to place the caret, but scrolling to the right line
             # should already be helpful.
-            self.editbox.see('%d.%d' % (line, column))
+            self.editbox.see('{0:d}.{1:d}'.format(line, column))
         # wait for user to push a button which will destroy (close) the window
         self.parent.mainloop()
         return self.text
@@ -486,7 +486,7 @@ class Tkdialog(object):
         """Constructor."""
         self.root = Tkinter.Tk()
         # "%dx%d%+d%+d" % (width, height, xoffset, yoffset)
-        self.root.geometry("%ix%i+10-10" % (pywikibot.config.tkhorsize,
+        self.root.geometry("{0:d}x{1:d}+10-10".format(pywikibot.config.tkhorsize,
                                             pywikibot.config.tkvertsize))
 
         self.root.title(filename)

--- a/pywikibot/userinterfaces/terminal_interface_base.py
+++ b/pywikibot/userinterfaces/terminal_interface_base.py
@@ -49,7 +49,7 @@ colors = [
     'white',
 ]
 
-colorTagR = re.compile('\03{(?P<name>%s|previous)}' % '|'.join(colors))
+colorTagR = re.compile('\03{{(?P<name>{0!s}|previous)}}'.format('|'.join(colors)))
 
 
 class UI(object):
@@ -204,8 +204,7 @@ class UI(object):
                     # transliteration was successful. The replacement
                     # could consist of multiple letters.
                     # mark the transliterated letters in yellow.
-                    transliteratedText += '\03{lightyellow}%s\03{previous}' \
-                                          % transliterated
+                    transliteratedText += '\03{{lightyellow}}{0!s}\03{{previous}}'.format(transliterated)
                     # memorize if we replaced a single letter by multiple
                     # letters.
                     if len(transliterated) > 0:
@@ -260,7 +259,7 @@ class UI(object):
             question = question[:-1]
             end_marker = '?'
         if default:
-            question = question + ' (default: %s)' % default
+            question = question + ' (default: {0!s})'.format(default)
         question = question + end_marker
         if force:
             self.output(question + '\n')

--- a/pywikibot/userinterfaces/terminal_interface_win32.py
+++ b/pywikibot/userinterfaces/terminal_interface_win32.py
@@ -42,7 +42,7 @@ windowsColors = {
     'white':       15,
 }
 
-colorTagR = re.compile('\03{(?P<name>%s)}' % '|'.join(list(windowsColors.keys())))
+colorTagR = re.compile('\03{{(?P<name>{0!s})}}'.format('|'.join(list(windowsColors.keys()))))
 
 
 # Compat for python <= 2.5

--- a/pywikibot/userinterfaces/transliteration.py
+++ b/pywikibot/userinterfaces/transliteration.py
@@ -2816,7 +2816,7 @@ class transliterator(object):
             if value == "?":
                 continue
             while value.encode(encoding, 'replace').decode(encoding) == "?" and value in self.trans:
-                assert value != self.trans[value], "%r == self.trans[%r]!" % (value, value)
+                assert value != self.trans[value], "{0!r} == self.trans[{1!r}]!".format(value, value)
                 value = self.trans[value]
             self.trans[char] = value
 

--- a/pywikibot/userinterfaces/win32_unicode.py
+++ b/pywikibot/userinterfaces/win32_unicode.py
@@ -113,8 +113,7 @@ class UnicodeOutput(IOBase):
             try:
                 self._stream.flush()
             except Exception as e:
-                _complain("%s.flush: %r from %r"
-                          % (self.name, e, self._stream))
+                _complain("{0!s}.flush: {1!r} from {2!r}".format(self.name, e, self._stream))
                 raise
 
     def write(self, text):
@@ -137,14 +136,13 @@ class UnicodeOutput(IOBase):
                                            min(remaining, 10000),
                                            byref(n), None)
                     if retval == 0 or n.value == 0:
-                        raise IOError("WriteConsoleW returned %r, n.value = %r"
-                                      % (retval, n.value))
+                        raise IOError("WriteConsoleW returned {0!r}, n.value = {1!r}".format(retval, n.value))
                     remaining -= n.value
                     if remaining == 0:
                         break
                     text = text[n.value:]
         except Exception as e:
-            _complain("%s.write: %r" % (self.name, e))
+            _complain("{0!s}.write: {1!r}".format(self.name, e))
             raise
 
     def writelines(self, lines):
@@ -153,7 +151,7 @@ class UnicodeOutput(IOBase):
             for line in lines:
                 self.write(line)
         except Exception as e:
-            _complain("%s.writelines: %r" % (self.name, e))
+            _complain("{0!s}.writelines: {1!r}".format(self.name, e))
             raise
 
 
@@ -329,7 +327,7 @@ def get_unicode_console():
                 stderr = UnicodeOutput(None, sys.stderr, old_stderr_fileno,
                                        '<Unicode redirected stderr>')
     except Exception as e:
-        _complain("exception %r while fixing up sys.stdout and sys.stderr" % (e,))
+        _complain("exception {0!r} while fixing up sys.stdout and sys.stderr".format(e))
 
     # While we're at it, let's unmangle the command-line arguments:
 

--- a/pywikibot/version.py
+++ b/pywikibot/version.py
@@ -72,7 +72,7 @@ def getversion(online=True):
             pass
 
     data['hsh'] = data['hsh'][:7]  # make short hash from full hash
-    return '%(tag)s (%(hsh)s, %(rev)s, %(date)s, %(cmp_ver)s)' % data
+    return '{tag!s} ({hsh!s}, {rev!s}, {date!s}, {cmp_ver!s})'.format(**data)
 
 
 def getversiondict():
@@ -112,11 +112,9 @@ def getversiondict():
 
     # git and svn can silently fail, as it may be a nightly.
     if getversion_package in exceptions:
-        warn('Unable to detect version; exceptions raised:\n%r'
-             % exceptions, UserWarning)
+        warn('Unable to detect version; exceptions raised:\n{0!r}'.format(exceptions), UserWarning)
     elif exceptions:
-        pywikibot.debug('version algorithm exceptions:\n%r'
-                        % exceptions, _logger)
+        pywikibot.debug('version algorithm exceptions:\n{0!r}'.format(exceptions), _logger)
 
     if isinstance(date, basestring):
         datestring = date
@@ -156,7 +154,7 @@ def svn_rev_info(path):
                 t = tag.split('://')
                 t[1] = t[1].replace('svn.wikimedia.org/svnroot/pywikipedia/',
                                     '')
-                tag = '[%s] %s' % (t[0], t[1])
+                tag = '[{0!s}] {1!s}'.format(t[0], t[1])
                 for i in range(4):
                     entries.readline()
                 date = time.strptime(entries.readline()[:19],
@@ -191,7 +189,7 @@ def github_svn_rev2hash(tag, rev):
     """
     from pywikibot.comms import http
 
-    uri = 'https://github.com/wikimedia/%s/!svn/vcc/default' % tag
+    uri = 'https://github.com/wikimedia/{0!s}/!svn/vcc/default'.format(tag)
     request = http.fetch(uri=uri, method='PROPFIND',
                          body="<?xml version='1.0' encoding='utf-8'?>"
                               "<propfind xmlns=\"DAV:\"><allprop/></propfind>",
@@ -226,13 +224,13 @@ def getversion_svn_setuptools(path=None):
     rev = svninfo.get_revision()
     log.set_threshold(old_level)
     if not isinstance(rev, int):
-        raise TypeError('SvnInfo.get_revision() returned type %s' % type(rev))
+        raise TypeError('SvnInfo.get_revision() returned type {0!s}'.format(type(rev)))
     if rev < 0:
-        raise ValueError('SvnInfo.get_revision() returned %d' % rev)
+        raise ValueError('SvnInfo.get_revision() returned {0:d}'.format(rev))
     if rev == 0:
         raise ParseError('SvnInfo: invalid workarea')
     hsh, date = github_svn_rev2hash(tag, rev)
-    rev = 's%s' % rev
+    rev = 's{0!s}'.format(rev)
     return (tag, rev, date, hsh)
 
 
@@ -259,7 +257,7 @@ def getversion_svn(path=None):
         for i in range(date.n_fields - 1):
             assert date[i] == date2[i], 'Date of version is not consistent'
 
-    rev = 's%s' % rev
+    rev = 's{0!s}'.format(rev)
     if (not date or not tag or not rev) and not path:
         raise ParseError
     return (tag, rev, date, hsh)
@@ -297,7 +295,7 @@ def getversion_git(path=None):
         e = tag.find('\n', s)
         tag = tag[(s + 6):e]
         t = tag.strip().split('/')
-        tag = '[%s] %s' % (t[0][:-1], '-'.join(t[3:]))
+        tag = '[{0!s}] {1!s}'.format(t[0][:-1], '-'.join(t[3:]))
     with subprocess.Popen([cmd, '--no-pager',
                            'log', '-1',
                            '--pretty=format:"%ad|%an|%h|%H|%d"'
@@ -313,7 +311,7 @@ def getversion_git(path=None):
                           cwd=_program_dir,
                           stdout=subprocess.PIPE).stdout as stdout:
         rev = stdout.read()
-    rev = 'g%s' % len(rev.splitlines())
+    rev = 'g{0!s}'.format(len(rev.splitlines()))
     hsh = info[3]  # also stored in '.git/refs/heads/master'
     if (not date or not tag or not rev) and not path:
         raise ParseError
@@ -411,7 +409,7 @@ def getfileversion(filename):
         stat = os.stat(fn)
         mtime = datetime.datetime.fromtimestamp(stat.st_mtime).isoformat(' ')
     if mtime and __version__:
-        return u'%s %s %s' % (filename, __version__[5:-1][:7], mtime)
+        return u'{0!s} {1!s} {2!s}'.format(filename, __version__[5:-1][:7], mtime)
     else:
         return None
 

--- a/pywikibot/xmlreader.py
+++ b/pywikibot/xmlreader.py
@@ -139,42 +139,42 @@ class XmlDump(object):
 
     def _parse_only_latest(self, event, elem):
         """Parser that yields only the latest revision."""
-        if event == "end" and elem.tag == "{%s}page" % self.uri:
+        if event == "end" and elem.tag == "{{{0!s}}}page".format(self.uri):
             self._headers(elem)
-            revision = elem.find("{%s}revision" % self.uri)
+            revision = elem.find("{{{0!s}}}revision".format(self.uri))
             yield self._create_revision(revision)
             elem.clear()
             self.root.clear()
 
     def _parse_all(self, event, elem):
         """Parser that yields all revisions."""
-        if event == "start" and elem.tag == "{%s}page" % self.uri:
+        if event == "start" and elem.tag == "{{{0!s}}}page".format(self.uri):
             self._headers(elem)
-        if event == "end" and elem.tag == "{%s}revision" % self.uri:
+        if event == "end" and elem.tag == "{{{0!s}}}revision".format(self.uri):
             yield self._create_revision(elem)
             elem.clear()
             self.root.clear()
 
     def _headers(self, elem):
         """Extract headers from XML chunk."""
-        self.title = elem.findtext("{%s}title" % self.uri)
-        self.ns = elem.findtext("{%s}ns" % self.uri)
-        self.pageid = elem.findtext("{%s}id" % self.uri)
-        self.restrictions = elem.findtext("{%s}restrictions" % self.uri)
-        self.isredirect = elem.findtext("{%s}redirect" % self.uri) is not None
+        self.title = elem.findtext("{{{0!s}}}title".format(self.uri))
+        self.ns = elem.findtext("{{{0!s}}}ns".format(self.uri))
+        self.pageid = elem.findtext("{{{0!s}}}id".format(self.uri))
+        self.restrictions = elem.findtext("{{{0!s}}}restrictions".format(self.uri))
+        self.isredirect = elem.findtext("{{{0!s}}}redirect".format(self.uri)) is not None
         self.editRestriction, self.moveRestriction = parseRestrictions(
             self.restrictions)
 
     def _create_revision(self, revision):
         """Create a Single revision."""
-        revisionid = revision.findtext("{%s}id" % self.uri)
-        timestamp = revision.findtext("{%s}timestamp" % self.uri)
-        comment = revision.findtext("{%s}comment" % self.uri)
-        contributor = revision.find("{%s}contributor" % self.uri)
-        ipeditor = contributor.findtext("{%s}ip" % self.uri)
-        username = ipeditor or contributor.findtext("{%s}username" % self.uri)
+        revisionid = revision.findtext("{{{0!s}}}id".format(self.uri))
+        timestamp = revision.findtext("{{{0!s}}}timestamp".format(self.uri))
+        comment = revision.findtext("{{{0!s}}}comment".format(self.uri))
+        contributor = revision.find("{{{0!s}}}contributor".format(self.uri))
+        ipeditor = contributor.findtext("{{{0!s}}}ip".format(self.uri))
+        username = ipeditor or contributor.findtext("{{{0!s}}}username".format(self.uri))
         # could get comment, minor as well
-        text = revision.findtext("{%s}text" % self.uri)
+        text = revision.findtext("{{{0!s}}}text".format(self.uri))
         return XmlEntry(title=self.title,
                         ns=self.ns,
                         id=self.pageid,

--- a/scripts/add_text.py
+++ b/scripts/add_text.py
@@ -131,20 +131,19 @@ def add_text(page, addText, summary=None, regexSkip=None,
     errorCount = 0
 
     if putText:
-        pywikibot.output(u'Loading %s...' % page.title())
+        pywikibot.output(u'Loading {0!s}...'.format(page.title()))
     if oldTextGiven is None:
         try:
             text = page.get()
         except pywikibot.NoPage:
             if create:
-                pywikibot.output(u"%s doesn't exist, creating it!"
-                                 % page.title())
+                pywikibot.output(u"{0!s} doesn't exist, creating it!".format(page.title()))
                 text = u''
             else:
-                pywikibot.output(u"%s doesn't exist, skip!" % page.title())
+                pywikibot.output(u"{0!s} doesn't exist, skip!".format(page.title()))
                 return (False, False, always)
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u"%s is a redirect, skip!" % page.title())
+            pywikibot.output(u"{0!s} is a redirect, skip!".format(page.title()))
             return (False, False, always)
     else:
         text = oldTextGiven
@@ -183,7 +182,7 @@ def add_text(page, addText, summary=None, regexSkip=None,
             newtext = textlib.removeLanguageLinks(newtext, site)
 
             # Adding the text
-            newtext += u"%s%s" % (config.line_separator, addText)
+            newtext += u"{0!s}{1!s}".format(config.line_separator, addText)
             # Reputting the categories
             newtext = textlib.replaceCategoryLinks(newtext,
                                                    categoriesInside, site,
@@ -193,8 +192,7 @@ def add_text(page, addText, summary=None, regexSkip=None,
             allstars = []
             starstext = textlib.removeDisabledParts(text)
             for star in starsList:
-                regex = re.compile('(\{\{(?:template:|)%s\|.*?\}\}[\s]*)'
-                                   % star, re.I)
+                regex = re.compile('(\{{\{{(?:template:|){0!s}\|.*?\}}\}}[\s]*)'.format(star), re.I)
                 found = regex.findall(starstext)
                 if found != []:
                     newtext = regex.sub('', newtext)
@@ -203,12 +201,12 @@ def add_text(page, addText, summary=None, regexSkip=None,
                 newtext = newtext.strip() + config.line_separator * 2
                 allstars.sort()
                 for element in allstars:
-                    newtext += '%s%s' % (element.strip(), config.LS)
+                    newtext += '{0!s}{1!s}'.format(element.strip(), config.LS)
             # Adding the interwiki
             newtext = textlib.replaceLanguageLinks(newtext, interwikiInside,
                                                    site)
         else:
-            newtext += u"%s%s" % (config.line_separator, addText)
+            newtext += u"{0!s}{1!s}".format(config.line_separator, addText)
     else:
         newtext = addText + config.line_separator + text
     if putText and text != newtext:
@@ -252,15 +250,13 @@ def add_text(page, addText, summary=None, regexSkip=None,
                         raise pywikibot.ServerError(u'Fifth Server Error!')
                 except pywikibot.SpamfilterError as e:
                     pywikibot.output(
-                        u'Cannot change %s because of blacklist entry %s'
-                        % (page.title(), e.url))
+                        u'Cannot change {0!s} because of blacklist entry {1!s}'.format(page.title(), e.url))
                     return (False, False, always)
                 except pywikibot.LockedPage:
-                    pywikibot.output(u'Skipping %s (locked page)'
-                                     % page.title())
+                    pywikibot.output(u'Skipping {0!s} (locked page)'.format(page.title()))
                     return (False, False, always)
                 except pywikibot.PageNotSaved as error:
-                    pywikibot.output(u'Error putting page: %s' % error.args)
+                    pywikibot.output(u'Error putting page: {0!s}'.format(error.args))
                     return (False, False, always)
                 else:
                     # Break only if the errors are one after the other...

--- a/scripts/archive/featured.py
+++ b/scripts/archive/featured.py
@@ -271,8 +271,7 @@ class FeaturedBot(pywikibot.Bot):
                 try:
                     site = self.site.fromDBName(key)
                 except pywikibot.SiteDefinitionError:
-                    pywikibot.output('"%s" is not a valid site. Skipping...'
-                                     % key)
+                    pywikibot.output('"{0!s}" is not a valid site. Skipping...'.format(key))
                 else:
                     if site.family == self.site.family:
                         yield site
@@ -322,17 +321,15 @@ class FeaturedBot(pywikibot.Bot):
             f = open(self.filename, "rb")
             self.cache = pickle.load(f)
             f.close()
-            pywikibot.output(u'Cache file %s found with %d items.'
-                             % (self.filename, len(self.cache)))
+            pywikibot.output(u'Cache file {0!s} found with {1:d} items.'.format(self.filename, len(self.cache)))
         except IOError:
-            pywikibot.output(u'Cache file %s not found.' % self.filename)
+            pywikibot.output(u'Cache file {0!s} not found.'.format(self.filename))
 
     def writecache(self):
         if self.getOption('count'):
             return
         if not self.getOption('nocache') is True:
-            pywikibot.output(u'Writing %d items to cache file %s.'
-                             % (len(self.cache), self.filename))
+            pywikibot.output(u'Writing {0:d} items to cache file {1!s}.'.format(len(self.cache), self.filename))
             with open(self.filename, "wb") as f:
                 pickle.dump(self.cache, f, protocol=config.pickle_protocol)
         self.cache = dict()
@@ -340,12 +337,11 @@ class FeaturedBot(pywikibot.Bot):
     def run(self):
         for task in self.tasks:
             self.run_task(task)
-        pywikibot.output(u'%d pages written.' % self._save_counter)
+        pywikibot.output(u'{0:d} pages written.'.format(self._save_counter))
 
     def run_task(self, task):
         if not self.hastemplate(task):
-            pywikibot.output(u'\nNOTE: %s articles are not implemented at %s.'
-                             % (task, self.site))
+            pywikibot.output(u'\nNOTE: {0!s} articles are not implemented at {1!s}.'.format(task, self.site))
             return
 
         self.readcache(task)
@@ -353,7 +349,7 @@ class FeaturedBot(pywikibot.Bot):
             try:
                 self.treat(site, task)
             except KeyboardInterrupt:
-                pywikibot.output('\nQuitting %s treat...' % task)
+                pywikibot.output('\nQuitting {0!s} treat...'.format(task))
                 break
         self.writecache()
 
@@ -372,8 +368,7 @@ class FeaturedBot(pywikibot.Bot):
             method = info[code][0]
         except KeyError:
             pywikibot.error(
-                u'language %s doesn\'t has %s category source.'
-                % (code, task))
+                u'language {0!s} doesn\'t has {1!s} category source.'.format(code, task))
             return
         name = info[code][1]
         # hide #-sorted items on en-wiki
@@ -397,11 +392,11 @@ class FeaturedBot(pywikibot.Bot):
                 continue
 
             if u"/" in p.title() and p.namespace() != 0:
-                pywikibot.output(u"%s is a subpage" % p.title())
+                pywikibot.output(u"{0!s} is a subpage".format(p.title()))
                 continue
 
             if p.title() in cache:
-                pywikibot.output(u"(cached) %s -> %s" % (p.title(),
+                pywikibot.output(u"(cached) {0!s} -> {1!s}".format(p.title(),
                                                          cache[p.title()]))
                 continue
             yield p
@@ -421,28 +416,22 @@ class FeaturedBot(pywikibot.Bot):
 
         if not ourpage:
             if not quiet:
-                pywikibot.output(u"%s -> no corresponding page in %s"
-                                 % (page.title(), oursite))
+                pywikibot.output(u"{0!s} -> no corresponding page in {1!s}".format(page.title(), oursite))
         elif ourpage.section():
-            pywikibot.output(u"%s -> our page is a section link: %s"
-                             % (page.title(), ourpage.title()))
+            pywikibot.output(u"{0!s} -> our page is a section link: {1!s}".format(page.title(), ourpage.title()))
         elif not ourpage.exists():
-            pywikibot.output(u"%s -> our page doesn't exist: %s"
-                             % (page.title(), ourpage.title()))
+            pywikibot.output(u"{0!s} -> our page doesn't exist: {1!s}".format(page.title(), ourpage.title()))
         else:
             if ourpage.isRedirectPage():
                 ourpage = ourpage.getRedirectTarget()
 
-            pywikibot.output(u"%s -> corresponding page is %s"
-                             % (page.title(), ourpage.title()))
+            pywikibot.output(u"{0!s} -> corresponding page is {1!s}".format(page.title(), ourpage.title()))
             if ourpage.namespace() != 0:
-                pywikibot.output(u"%s -> not in the main namespace, skipping"
-                                 % page.title())
+                pywikibot.output(u"{0!s} -> not in the main namespace, skipping".format(page.title()))
             elif ourpage.isRedirectPage():
-                pywikibot.output(u"%s -> double redirect, skipping" % page.title())
+                pywikibot.output(u"{0!s} -> double redirect, skipping".format(page.title()))
             elif not ourpage.exists():
-                pywikibot.output(u"%s -> page doesn't exist, skipping"
-                                 % ourpage.title())
+                pywikibot.output(u"{0!s} -> page doesn't exist, skipping".format(ourpage.title()))
             else:
                 backpage = None
                 for link in ourpage.iterlanglinks():
@@ -450,7 +439,7 @@ class FeaturedBot(pywikibot.Bot):
                         backpage = pywikibot.Page(link)
                         break
                 if not backpage:
-                    pywikibot.output(u"%s -> no back interwiki ref" % page.title())
+                    pywikibot.output(u"{0!s} -> no back interwiki ref".format(page.title()))
                 elif backpage == page:
                     # everything is ok
                     yield ourpage
@@ -461,11 +450,9 @@ class FeaturedBot(pywikibot.Bot):
                         yield ourpage
                     else:
                         pywikibot.output(
-                            u"%s -> back interwiki ref target is redirect to %s"
-                            % (page.title(), backpage.title()))
+                            u"{0!s} -> back interwiki ref target is redirect to {1!s}".format(page.title(), backpage.title()))
                 else:
-                    pywikibot.output(u"%s -> back interwiki ref target is %s"
-                                     % (page.title(), backpage.title()))
+                    pywikibot.output(u"{0!s} -> back interwiki ref target is {1!s}".format(page.title(), backpage.title()))
 
     def getTemplateList(self, code, task):
         add_templates = []
@@ -534,8 +521,7 @@ class FeaturedBot(pywikibot.Bot):
                 source = source.getRedirectTarget()
 
             if not source.exists():
-                pywikibot.output(u"source page doesn't exist: %s"
-                                 % source)
+                pywikibot.output(u"source page doesn't exist: {0!s}".format(source))
                 continue
 
             for dest in self.findTranslated(source, tosite):
@@ -546,9 +532,8 @@ class FeaturedBot(pywikibot.Bot):
         """Place or remove the Link_GA/FA template on/from a page."""
         def compile_link(site, templates):
             """Compile one link template list."""
-            findtemplate = '(%s)' % '|'.join(templates)
-            return re.compile(r"\{\{%s\|%s\}\}"
-                              % (findtemplate.replace(u' ', u'[ _]'),
+            findtemplate = '({0!s})'.format('|'.join(templates))
+            return re.compile(r"\{{\{{{0!s}\|{1!s}\}}\}}".format(findtemplate.replace(u' ', u'[ _]'),
                                  site.code), re.IGNORECASE)
 
         tosite = dest.site
@@ -568,20 +553,19 @@ class FeaturedBot(pywikibot.Bot):
                 # insert just before interwiki
                 if (not interactive or
                     pywikibot.input_yn(
-                        u'Connecting %s -> %s. Proceed?'
-                        % (source.title(), dest.title()),
+                        u'Connecting {0!s} -> {1!s}. Proceed?'.format(source.title(), dest.title()),
                         default=False, automatic_quit=False)):
                     if self.getOption('side'):
                         # Placing {{Link FA|xx}} right next to
                         # corresponding interwiki
                         text = (text[:m1.end()] +
-                                u" {{%s|%s}}" % (add_tl[0], fromsite.code) +
+                                u" {{{{{0!s}|{1!s}}}}}".format(add_tl[0], fromsite.code) +
                                 text[m1.end():])
                     else:
                         # Moving {{Link FA|xx}} to top of interwikis
                         iw = textlib.getLanguageLinks(text, tosite)
                         text = textlib.removeLanguageLinks(text, tosite)
-                        text += u"%s{{%s|%s}}%s" % (config.LS, add_tl[0],
+                        text += u"{0!s}{{{{{1!s}|{2!s}}}}}{3!s}".format(config.LS, add_tl[0],
                                                     fromsite.code, config.LS)
                         text = textlib.replaceLanguageLinks(text,
                                                             iw, tosite)
@@ -591,8 +575,7 @@ class FeaturedBot(pywikibot.Bot):
                 if (changed or  # Don't force the user to say "Y" twice
                     not interactive or
                     pywikibot.input_yn(
-                        u'Connecting %s -> %s. Proceed?'
-                        % (source.title(), dest.title()),
+                        u'Connecting {0!s} -> {1!s}. Proceed?'.format(source.title(), dest.title()),
                         default=False, automatic_quit=False)):
                     text = re.sub(re_Link_remove, '', text)
                     changed = True
@@ -605,8 +588,7 @@ class FeaturedBot(pywikibot.Bot):
                 dest.put(text, comment)
                 self._save_counter += 1
             except pywikibot.LockedPage:
-                pywikibot.output(u'Page %s is locked!'
-                                 % dest.title())
+                pywikibot.output(u'Page {0!s} is locked!'.format(dest.title()))
             except pywikibot.PageNotSaved:
                 pywikibot.output(u"Page not saved")
 

--- a/scripts/archivebot.py
+++ b/scripts/archivebot.py
@@ -251,13 +251,13 @@ def template_title_regex(tpl_page):
     marker = '?' if ns.id == 10 else ''
     title = tpl_page.title(withNamespace=False)
     if ns.case != 'case-sensitive':
-        title = '[%s%s]%s' % (re.escape(title[0].upper()),
+        title = '[{0!s}{1!s}]{2!s}'.format(re.escape(title[0].upper()),
                               re.escape(title[0].lower()),
                               re.escape(title[1:]))
     else:
         title = re.escape(title)
 
-    return re.compile(r'(?:(?:%s):)%s%s' % (u'|'.join(ns), marker, title))
+    return re.compile(r'(?:(?:{0!s}):){1!s}{2!s}'.format(u'|'.join(ns), marker, title))
 
 
 class TZoneUTC(datetime.tzinfo):
@@ -278,7 +278,7 @@ class TZoneUTC(datetime.tzinfo):
 
     def __repr__(self):
         """Return a string representation."""
-        return "%s()" % self.__class__.__name__
+        return "{0!s}()".format(self.__class__.__name__)
 
 
 class DiscussionThread(object):
@@ -305,8 +305,7 @@ class DiscussionThread(object):
 
     def __repr__(self):
         """Return a string representation."""
-        return '%s("%s",%d bytes)' \
-               % (self.__class__.__name__, self.title,
+        return '{0!s}("{1!s}",{2:d} bytes)'.format(self.__class__.__name__, self.title,
                   len(self.content.encode('utf-8')))
 
     def feed_line(self, line):
@@ -330,7 +329,7 @@ class DiscussionThread(object):
 
     def to_text(self):
         """Return wikitext discussion thread."""
-        return u"== %s ==\n\n%s" % (self.title, self.content)
+        return u"== {0!s} ==\n\n{1!s}".format(self.title, self.content)
 
     def should_be_archived(self, archiver):
         """
@@ -417,8 +416,7 @@ class DiscussionPage(pywikibot.Page):
         # This extra info is not desirable when run under the unittest
         # framework, which may be run either directly or via setup.py
         if pywikibot.calledModuleName() not in ['archivebot_tests', 'setup']:
-            pywikibot.output(u'%d Threads found on %s'
-                             % (len(self.threads), self))
+            pywikibot.output(u'{0:d} Threads found on {1!s}'.format(len(self.threads), self))
 
     def feed_thread(self, thread, max_archive_size=(250 * 1024, 'B')):
         """Check whether archive size exceeded."""
@@ -505,9 +503,8 @@ class PageArchiver(object):
 
     def attr2text(self):
         """Return a template with archiver saveable attributes."""
-        return '{{%s\n%s\n}}' \
-               % (self.tpl.title(withNamespace=(self.tpl.namespace() != 10)),
-                  '\n'.join('|%s = %s' % (a, self.get_attr(a))
+        return '{{{{{0!s}\n{1!s}\n}}}}'.format(self.tpl.title(withNamespace=(self.tpl.namespace() != 10)),
+                  '\n'.join('|{0!s} = {1!s}'.format(a, self.get_attr(a))
                             for a in self.saveables()))
 
     def key_ok(self):
@@ -519,7 +516,7 @@ class PageArchiver(object):
 
     def load_config(self):
         """Load and validate archiver template."""
-        pywikibot.output(u'Looking for: {{%s}} in %s' % (self.tpl.title(), self.page))
+        pywikibot.output(u'Looking for: {{{{{0!s}}}}} in {1!s}'.format(self.tpl.title(), self.page))
         for tpl in self.page.templatesWithParams():
             if tpl[0] == pywikibot.Page(self.site, self.tpl.title(), ns=10):
                 for param in tpl[1]:
@@ -547,8 +544,7 @@ class PageArchiver(object):
            and not self.page.title() + '/' == title[:len(self.page.title()) + 1] \
            and not self.key_ok():
             raise ArchiveSecurityError(
-                u"Archive page %s does not start with page title (%s)!"
-                % (archive, self.page.title()))
+                u"Archive page {0!s} does not start with page title ({1!s})!".format(archive, self.page.title()))
         if title not in self.archives:
             self.archives[title] = DiscussionPage(archive, self, params)
         return self.archives[title].feed_thread(thread, max_archive_size)
@@ -560,7 +556,7 @@ class PageArchiver(object):
         oldthreads = self.page.threads
         self.page.threads = []
         whys = []
-        pywikibot.output(u'Processing %d threads' % len(oldthreads))
+        pywikibot.output(u'Processing {0:d} threads'.format(len(oldthreads)))
         for t in oldthreads:
             if len(oldthreads) - self.archived_threads \
                <= int(self.get_attr('minthreadsleft', 5)):
@@ -604,19 +600,17 @@ class PageArchiver(object):
         if self.archived_threads < mintoarchive:
             # We might not want to archive a measly few threads
             # (lowers edit frequency)
-            pywikibot.output(u'Only %d (< %d) threads are old enough. Skipping'
-                             % (self.archived_threads, mintoarchive))
+            pywikibot.output(u'Only {0:d} (< {1:d}) threads are old enough. Skipping'.format(self.archived_threads, mintoarchive))
             return
         if whys:
             # Search for the marker template
-            rx = re.compile(r'\{\{%s\s*?\n.*?\n\}\}'
-                            % (template_title_regex(self.tpl).pattern), re.DOTALL)
+            rx = re.compile(r'\{{\{{{0!s}\s*?\n.*?\n\}}\}}'.format((template_title_regex(self.tpl).pattern)), re.DOTALL)
             if not rx.search(self.page.header):
                 raise MalformedConfigError(
                     "Couldn't find the template in the header"
                 )
 
-            pywikibot.output(u'Archiving %d thread(s).' % self.archived_threads)
+            pywikibot.output(u'Archiving {0:d} thread(s).'.format(self.archived_threads))
             # Save the archives first (so that bugs don't cause a loss of data)
             for a in sorted(self.archives.keys()):
                 self.comment_params['count'] = self.archives[a].archived_threads
@@ -696,7 +690,7 @@ def main(*args):
         if page.exists():
             calc = page.title()
         else:
-            pywikibot.output(u'NOTE: the specified page "%s" does not (yet) exist.' % calc)
+            pywikibot.output(u'NOTE: the specified page "{0!s}" does not (yet) exist.'.format(calc))
         s = md5()
         s.update(salt + '\n')
         s.update(calc + '\n')
@@ -727,7 +721,7 @@ def main(*args):
             pagelist.append(pywikibot.Page(site, pagename, ns=3))
         pagelist = sorted(pagelist)
         for pg in iter(pagelist):
-            pywikibot.output(u'Processing %s' % pg)
+            pywikibot.output(u'Processing {0!s}'.format(pg))
             # Catching exceptions, so that errors in one page do not bail out
             # the entire process
             try:
@@ -735,10 +729,9 @@ def main(*args):
                 archiver.run()
             except ArchiveBotSiteConfigError as e:
                 # no stack trace for errors originated by pages on-site
-                pywikibot.error('Missing or malformed template in page %s: %s'
-                                % (pg, e))
+                pywikibot.error('Missing or malformed template in page {0!s}: {1!s}'.format(pg, e))
             except Exception:
-                pywikibot.error(u'Error occurred while processing page %s' % pg)
+                pywikibot.error(u'Error occurred while processing page {0!s}'.format(pg))
                 pywikibot.exception(tb=True)
 
 if __name__ == '__main__':

--- a/scripts/basic.py
+++ b/scripts/basic.py
@@ -82,18 +82,16 @@ class BasicBot(SingleSiteBot):
 
         if not self.userPut(page, page.text, text, summary=self.summary,
                             ignore_save_related_errors=True):
-            pywikibot.output(u'Page %s not saved.' % page.title(asLink=True))
+            pywikibot.output(u'Page {0!s} not saved.'.format(page.title(asLink=True)))
 
     def load(self, page):
         """Load the text of the given page."""
         try:
             text = page.get()
         except pywikibot.NoPage:
-            pywikibot.output(u"Page %s does not exist; skipping."
-                             % page.title(asLink=True))
+            pywikibot.output(u"Page {0!s} does not exist; skipping.".format(page.title(asLink=True)))
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u"Page %s is a redirect; skipping."
-                             % page.title(asLink=True))
+            pywikibot.output(u"Page {0!s} is a redirect; skipping.".format(page.title(asLink=True)))
         else:
             return text
         return None

--- a/scripts/blockpageschecker.py
+++ b/scripts/blockpageschecker.py
@@ -191,7 +191,7 @@ def showQuest(page):
         [('with browser', 'b'), ('with gui', 'g'), ('no', 'n')], 'n',
         automatic_quit=False)
     if quest == 'b':
-        webbrowser.open('%s?redirect=no' % page.full_url())
+        webbrowser.open('{0!s}?redirect=no'.format(page.full_url()))
     elif quest == 'g':
         from pywikibot import editor as editarticle
         editor = editarticle.TextEditor()
@@ -280,14 +280,14 @@ def main(*args):
     preloadingGen = pagegenerators.PreloadingGenerator(generator, groupsize=60)
     for page in preloadingGen:
         pagename = page.title(asLink=True)
-        pywikibot.output('Loading %s...' % pagename)
+        pywikibot.output('Loading {0!s}...'.format(pagename))
         try:
             text = page.text
         except pywikibot.NoPage:
-            pywikibot.output("%s doesn't exist! Skipping..." % pagename)
+            pywikibot.output("{0!s} doesn't exist! Skipping...".format(pagename))
             continue
         except pywikibot.IsRedirectPage:
-            pywikibot.output("%s is a redirect! Skipping..." % pagename)
+            pywikibot.output("{0!s} is a redirect! Skipping...".format(pagename))
             if show:
                 showQuest(page)
             continue
@@ -330,14 +330,13 @@ def main(*args):
                 replaceToPerform = u'|'.join(TTP + TSP + TU)
             else:
                 replaceToPerform = u'|'.join(TTP + TSP)
-            text, changes = re.subn('<noinclude>(%s)</noinclude>'
-                                    % replaceToPerform, '', text)
+            text, changes = re.subn('<noinclude>({0!s})</noinclude>'.format(replaceToPerform), '', text)
             if changes == 0:
-                text, changes = re.subn('(%s)' % replaceToPerform, '', text)
+                text, changes = re.subn('({0!s})'.format(replaceToPerform), '', text)
             msg = u'The page is editable for all'
             if not moveBlockCheck:
                 msg += u', deleting the template..'
-            pywikibot.output(u'%s.' % msg)
+            pywikibot.output(u'{0!s}.'.format(msg))
 
         elif editRestr[0] == 'sysop':
             # total edit protection
@@ -403,10 +402,9 @@ def main(*args):
                     replaceToPerform = u'|'.join(TSMP + TTMP + TU)
                 else:
                     replaceToPerform = u'|'.join(TSMP + TTMP)
-                text, changes = re.subn('<noinclude>(%s)</noinclude>'
-                                        % replaceToPerform, '', text)
+                text, changes = re.subn('<noinclude>({0!s})</noinclude>'.format(replaceToPerform), '', text)
                 if changes == 0:
-                    text, changes = re.subn('(%s)' % replaceToPerform, '', text)
+                    text, changes = re.subn('({0!s})'.format(replaceToPerform), '', text)
             elif moveRestr[0] == 'sysop':
                 # move-total-protection
                 if (TemplateInThePage[0] == 'sysop-move' and TTMP) or \
@@ -492,8 +490,7 @@ def main(*args):
                                          u'Skipping...')
                         break
                     except pywikibot.PageNotSaved as error:
-                        pywikibot.output(u'Error putting page: %s'
-                                         % (error.args,))
+                        pywikibot.output(u'Error putting page: {0!s}'.format(error.args))
                         break
                     else:
                         # Break only if the errors are one after the other

--- a/scripts/blockreview.py
+++ b/scripts/blockreview.py
@@ -94,8 +94,7 @@ class BlockreviewBot(ExistingPageBot, SingleSiteBot):
                                      self.unblock_tpl[self.site.code],
                                      ns=10)
         except KeyError:
-            pywikibot.error(u'Language "%s" not supported by this bot.'
-                            % self.site.code)
+            pywikibot.error(u'Language "{0!s}" not supported by this bot.'.format(self.site.code))
             raise SystemExit
         return genPage.getReferences(follow_redirects=False,
                                      withTemplateInclusion=True,
@@ -156,10 +155,10 @@ class BlockreviewBot(ExistingPageBot, SingleSiteBot):
                             for sysop in gen:
                                 pywikibot.output(sysop.title())
 
-                        talkText = talkText.replace(u'{{%s}}' % unblock_tpl,
-                                                    u'{{%s|2}}' % unblock_tpl)
-                        talkText = talkText.replace(u'{{%s|1}}' % unblock_tpl,
-                                                    u'{{%s|2}}' % unblock_tpl)
+                        talkText = talkText.replace(u'{{{{{0!s}}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|2}}}}'.format(unblock_tpl))
+                        talkText = talkText.replace(u'{{{{{0!s}|1}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|2}}}}'.format(unblock_tpl))
                         talkComment = i18n.translate(self.site.code,
                                                      self.msg_user
                                                      % self.parts)
@@ -175,10 +174,10 @@ class BlockreviewBot(ExistingPageBot, SingleSiteBot):
                                          ignore_save_related_errors=True)
                     else:
                         # nicht blockiert. Fall auf DS abschließen
-                        talkText = talkText.replace(u'{{%s}}' % unblock_tpl,
-                                                    u'{{%s|4}}' % unblock_tpl)
-                        talkText = talkText.replace(u'{{%s|1}}' % unblock_tpl,
-                                                    u'{{%s|4}}' % unblock_tpl)
+                        talkText = talkText.replace(u'{{{{{0!s}}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|4}}}}'.format(unblock_tpl))
+                        talkText = talkText.replace(u'{{{{{0!s}|1}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|4}}}}'.format(unblock_tpl))
                         talkComment = i18n.translate(self.site.code,
                                                      self.msg_done)
                 # Step 2
@@ -200,14 +199,13 @@ class BlockreviewBot(ExistingPageBot, SingleSiteBot):
                         self.userPut(project, project.text, projText,
                                      summary=comment, botflag=False,
                                      ignore_save_related_errors=True)
-                        talkText = talkText.replace(u'{{%s|2}}' % unblock_tpl,
-                                                    u'{{%s|3}}' % unblock_tpl)
-                        talkComment = u'Bot: [[%s|Wikipedia:Sperrprüfung]] eingetragen' \
-                                      % project_name
+                        talkText = talkText.replace(u'{{{{{0!s}|2}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|3}}}}'.format(unblock_tpl))
+                        talkComment = u'Bot: [[{0!s}|Wikipedia:Sperrprüfung]] eingetragen'.format(project_name)
                     else:
                         # User is unblocked. Review can be closed
-                        talkText = talkText.replace(u'{{%s|2}}' % unblock_tpl,
-                                                    u'{{%s|4}}' % unblock_tpl)
+                        talkText = talkText.replace(u'{{{{{0!s}|2}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|4}}}}'.format(unblock_tpl))
                         talkComment = i18n.translate(self.site.code,
                                                      self.msg_done)
                 # Step 3
@@ -219,8 +217,8 @@ class BlockreviewBot(ExistingPageBot, SingleSiteBot):
                         pass
                     else:
                         # User is unblocked. Review can be closed
-                        talkText = talkText.replace(u'{{%s|3}}' % unblock_tpl,
-                                                    u'{{%s|4}}' % unblock_tpl)
+                        talkText = talkText.replace(u'{{{{{0!s}|3}}}}'.format(unblock_tpl),
+                                                    u'{{{{{0!s}|4}}}}'.format(unblock_tpl))
                         talkComment = i18n.translate(self.site.code,
                                                      self.msg_done)
                 # Step 4

--- a/scripts/capitalize_redirects.py
+++ b/scripts/capitalize_redirects.py
@@ -75,11 +75,9 @@ class CapitalizeBot(MultipleSitesBot, FollowRedirectPageBot, ExistingPageBot):
         else:
             page_cap = pywikibot.Page(site, page_t.capitalize())
         if page_cap.exists():
-            pywikibot.output(u'%s already exists, skipping...\n'
-                             % page_cap.title(asLink=True))
+            pywikibot.output(u'{0!s} already exists, skipping...\n'.format(page_cap.title(asLink=True)))
         else:
-            pywikibot.output(u'%s doesn\'t exist'
-                             % page_cap.title(asLink=True))
+            pywikibot.output(u'{0!s} doesn\'t exist'.format(page_cap.title(asLink=True)))
             if self.user_confirm('Do you want to create a redirect?'):
                 comment = i18n.twtranslate(
                     site,

--- a/scripts/casechecker.py
+++ b/scripts/casechecker.py
@@ -122,7 +122,7 @@ class CaseChecker(object):
             elif arg == '-failed':
                 self.doFailed = True
             else:
-                pywikibot.output(u'Unknown argument %s.' % arg)
+                pywikibot.output(u'Unknown argument {0!s}.'.format(arg))
                 pywikibot.showHelp()
                 sys.exit()
 
@@ -191,11 +191,9 @@ class CaseChecker(object):
             self.lclToLatKeybDict = {}
             self.latToLclKeybDict = {}
 
-        badPtrnStr = u'([%s][%s]|[%s][%s])' \
-                     % (ascii_letters, self.localLtr,
+        badPtrnStr = u'([{0!s}][{1!s}]|[{2!s}][{3!s}])'.format(ascii_letters, self.localLtr,
                         self.localLtr, ascii_letters)
-        self.badWordPtrn = re.compile(u'[%s%s]*%s[%s%s]*'
-                                      % (ascii_letters, self.localLtr,
+        self.badWordPtrn = re.compile(u'[{0!s}{1!s}]*{2!s}[{3!s}{4!s}]*'.format(ascii_letters, self.localLtr,
                                          badPtrnStr, ascii_letters,
                                          self.localLtr))
 
@@ -206,7 +204,7 @@ class CaseChecker(object):
         # TODO: handle "continue"
         if self.site.code in self.whitelists:
             wlpage = self.whitelists[self.site.code]
-            pywikibot.output(u'Loading whitelist from %s' % wlpage)
+            pywikibot.output(u'Loading whitelist from {0!s}'.format(wlpage))
             wlparams = {
                 'action': 'query',
                 'prop': 'links',
@@ -229,15 +227,12 @@ class CaseChecker(object):
             else:
                 raise ValueError(u'The number of pageids is not 1')
 
-            pywikibot.output(u'Loaded whitelist with %i items'
-                             % len(self.knownWords))
+            pywikibot.output(u'Loaded whitelist with {0:d} items'.format(len(self.knownWords)))
             if len(self.knownWords) > 0:
-                pywikibot.log(u'Whitelist: %s'
-                              % u', '.join([self.MakeLink(i, False)
-                                            for i in self.knownWords]))
+                pywikibot.log(u'Whitelist: {0!s}'.format(u', '.join([self.MakeLink(i, False)
+                                            for i in self.knownWords])))
         else:
-            pywikibot.output(u'Whitelist is not known for language %s'
-                             % self.site.code)
+            pywikibot.output(u'Whitelist is not known for language {0!s}'.format(self.site.code))
 
     def RunQuery(self, params):
         """API query."""
@@ -270,7 +265,7 @@ class CaseChecker(object):
             elif 'allpages' in qc:
                 params.update(qc['allpages'])
             else:
-                raise ValueError(u'Unexpected query-continue values: %s' % qc)
+                raise ValueError(u'Unexpected query-continue values: {0!s}'.format(qc))
             continue
 
     def Run(self):
@@ -294,8 +289,7 @@ class CaseChecker(object):
                     for data in self.RunQuery(self.queryParams):
                         self.ProcessDataBlock(data)
         except:
-            pywikibot.output(u'Exception at Title = %s, Next = %s'
-                             % (self.currentTitle, self.apfrom))
+            pywikibot.output(u'Exception at Title = {0!s}, Next = {1!s}'.format(self.currentTitle, self.apfrom))
             try:
                 import traceback
                 pywikibot.output(traceback.format_exc())
@@ -317,7 +311,7 @@ class CaseChecker(object):
                 continue
             if firstItem:
                 if self.lastLetter != title[0]:
-                    pywikibot.ui.output('Processing %s\n' % title)
+                    pywikibot.ui.output('Processing {0!s}\n'.format(title))
                     self.lastLetter = title[0]
                 firstItem = False
             if self.titles:
@@ -432,12 +426,11 @@ class CaseChecker(object):
                                                                newTitle)
                             if not newTitle:
                                 if not printed:
-                                    self.WikiLog(u"* %s: link to %s"
-                                                 % (self.MakeLink(title, False),
+                                    self.WikiLog(u"* {0!s}: link to {1!s}".format(self.MakeLink(title, False),
                                                     err[0]))
                                     printed = True
                                 else:
-                                    self.WikiLog(u"** link to %s" % err[0])
+                                    self.WikiLog(u"** link to {0!s}".format(err[0]))
                     if pageObj is not None:
                         if self.PutNewPage(pageObj, pageTxt, msg):
                                 # done, no need to log anything
@@ -624,7 +617,7 @@ class CaseChecker(object):
                     msg = u'Redirect to ' + pagesRedir[t]
                 else:
                     msg = u'page exists'
-                self.ColorCodeWord(u'  %d: %s (%s)\n' % (count, t, msg), True)
+                self.ColorCodeWord(u'  {0:d}: {1!s} ({2!s})\n'.format(count, t, msg), True)
                 count += 1
             answers = [('skip', 's')] + [(str(i), i) for i in range(1, count)]
             choice = pywikibot.input_choice(u'Which link to choose?', answers)
@@ -703,9 +696,7 @@ class CaseChecker(object):
         else:
             count = str(cl if cl > 0 else 'no backlinks')
 
-        self.AppendLineToLog(self.nosuggestions, u'* %s (%s%s)'
-                             % (self.MakeLink(title), count, u', %d redirects'
-                                % redirs if redirs > 0 else u''))
+        self.AppendLineToLog(self.nosuggestions, u'* {0!s} ({1!s}{2!s})'.format(self.MakeLink(title), count, u', {0:d} redirects'.format(redirs) if redirs > 0 else u''))
         return False
 
     def PutNewPage(self, pageObj, pageTxt, msg):
@@ -713,15 +704,13 @@ class CaseChecker(object):
         title = pageObj.title(asLink=True, textlink=True)
         coloredMsg = u', '.join([self.ColorCodeWord(m) for m in msg])
         if pageObj.text == pageTxt:
-            self.WikiLog(u"* Error: Text replacement failed in %s (%s)"
-                         % (self.MakeLink(title, False), coloredMsg))
+            self.WikiLog(u"* Error: Text replacement failed in {0!s} ({1!s})".format(self.MakeLink(title, False), coloredMsg))
         else:
-            pywikibot.output(u'Case Replacements: %s' % u', '.join(msg))
+            pywikibot.output(u'Case Replacements: {0!s}'.format(u', '.join(msg)))
             pageObj.text = pageTxt
             try:
                 pageObj.save(
-                    u'%s: %s'
-                    % (i18n.twtranslate(
+                    u'{0!s}: {1!s}'.format(i18n.twtranslate(
                         self.site,
                         "casechecker-replacement-summary"),
                         self.site.mediawiki_message(u"comma-separator").join(msg)))
@@ -729,8 +718,7 @@ class CaseChecker(object):
             except KeyboardInterrupt:
                 raise
             except (pywikibot.LockedPage, pywikibot.PageNotSaved):
-                self.WikiLog(u"* Error: Could not save updated page %s (%s)"
-                             % (self.MakeLink(title, False), coloredMsg))
+                self.WikiLog(u"* Error: Could not save updated page {0!s} ({1!s})".format(self.MakeLink(title, False), coloredMsg))
         return False
 
     def MakeMoveSummary(self, fromTitle, toTitle):
@@ -741,8 +729,8 @@ class CaseChecker(object):
     def MakeLink(self, title, colorcode=True):
         """Create a colored link string."""
         prf = u'' if self.Page(title).namespace() == 0 else u':'
-        cc = u'|««« %s »»»' % self.ColorCodeWord(title) if colorcode else u''
-        return u"[[%s%s%s]]" % (prf, title, cc)
+        cc = u'|««« {0!s} »»»'.format(self.ColorCodeWord(title)) if colorcode else u''
+        return u"[[{0!s}{1!s}{2!s}]]".format(prf, title, cc)
 
     def OpenLogFile(self, filename):
         """Open logfile."""

--- a/scripts/catall.py
+++ b/scripts/catall.py
@@ -77,7 +77,7 @@ def make_categories(page, list, site=None):
         site = pywikibot.Site()
     pllist = []
     for p in list:
-        cattitle = "%s:%s" % (site.namespaces.CATEGORY, p)
+        cattitle = "{0!s}:{1!s}".format(site.namespaces.CATEGORY, p)
         pllist.append(pywikibot.Page(site, cattitle))
     page.put_async(textlib.replaceCategoryLinks(page.get(), pllist,
                                                 site=page.site),
@@ -111,14 +111,14 @@ def main(*args):
             text = p.get()
             cats = p.categories()
             if not cats:
-                pywikibot.output(u"========== %s ==========" % p.title())
+                pywikibot.output(u"========== {0!s} ==========".format(p.title()))
                 pywikibot.output('No categories')
                 pywikibot.output('-' * 40)
                 newcats = choosecats(text)
                 if newcats != [] and newcats is not None:
                     make_categories(p, newcats, mysite)
             elif docorrections:
-                pywikibot.output(u"========== %s ==========" % p.title())
+                pywikibot.output(u"========== {0!s} ==========".format(p.title()))
                 for c in cats:
                     pywikibot.output(c.title())
                 pywikibot.output('-' * 40)
@@ -128,7 +128,7 @@ def main(*args):
                 elif newcats != []:
                     make_categories(p, newcats, mysite)
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u'%s is a redirect' % p.title())
+            pywikibot.output(u'{0!s} is a redirect'.format(p.title()))
 
 if __name__ == "__main__":
     try:

--- a/scripts/category.py
+++ b/scripts/category.py
@@ -185,8 +185,7 @@ class CategoryDatabase(object):
     def _load(self):
         if not self.is_loaded:
             try:
-                pywikibot.output(u'Reading dump from %s'
-                                 % config.shortpath(self.filename))
+                pywikibot.output(u'Reading dump from {0!s}'.format(config.shortpath(self.filename)))
                 with open_archive(self.filename, 'rb') as f:
                     databases = pickle.load(f)
                 # keys are categories, values are 2-tuples with lists as
@@ -264,8 +263,7 @@ class CategoryDatabase(object):
         elif not os.path.isabs(filename):
             filename = config.datafilepath(filename)
         if self.is_loaded and (self.catContentDB or self.superclassDB):
-            pywikibot.output(u'Dumping to %s, please wait...'
-                             % config.shortpath(filename))
+            pywikibot.output(u'Dumping to {0!s}, please wait...'.format(config.shortpath(filename)))
             databases = {
                 'catContentDB': self.catContentDB,
                 'superclassDB': self.superclassDB
@@ -282,8 +280,7 @@ class CategoryDatabase(object):
             except EnvironmentError:
                 pass
             else:
-                pywikibot.output(u'Database is empty. %s removed'
-                                 % config.shortpath(filename))
+                pywikibot.output(u'Database is empty. {0!s} removed'.format(config.shortpath(filename)))
 
 
 class CategoryAddBot(MultipleSitesBot):
@@ -342,8 +339,7 @@ class CategoryAddBot(MultipleSitesBot):
             if self.follow_redirects:
                 self.current_page = redirTarget
             else:
-                pywikibot.warning(u"Page %s is a redirect to %s; skipping."
-                                  % (page.title(asLink=True),
+                pywikibot.warning(u"Page {0!s} is a redirect to {1!s}; skipping.".format(page.title(asLink=True),
                                      redirTarget.title(asLink=True)))
                 # loading it will throw an error if we don't jump out before
                 return
@@ -353,27 +349,24 @@ class CategoryAddBot(MultipleSitesBot):
             # Load the page
             text = self.current_page.text
         elif self.create:
-            pywikibot.output(u"Page %s doesn't exist yet; creating."
-                             % (self.current_page.title(asLink=True)))
+            pywikibot.output(u"Page {0!s} doesn't exist yet; creating.".format((self.current_page.title(asLink=True))))
             text = ''
         else:
-            pywikibot.output(u"Page %s does not exist; skipping."
-                             % self.current_page.title(asLink=True))
+            pywikibot.output(u"Page {0!s} does not exist; skipping.".format(self.current_page.title(asLink=True)))
             return
         # store old text, so we don't have reload it every time
         old_text = text
         cats = textlib.getCategoryLinks(text)
         pywikibot.output(u"Current categories:")
         for cat in cats:
-            pywikibot.output(u"* %s" % cat.title())
+            pywikibot.output(u"* {0!s}".format(cat.title()))
         catpl = pywikibot.Category(self.current_page.site, self.newcat)
         if catpl in cats:
-            pywikibot.output(u"%s is already in %s."
-                             % (self.current_page.title(), catpl.title()))
+            pywikibot.output(u"{0!s} is already in {1!s}.".format(self.current_page.title(), catpl.title()))
         else:
             if self.sort:
                 catpl = self.sorted_by_last_name(catpl, self.current_page)
-            pywikibot.output(u'Adding %s' % catpl.title(asLink=True))
+            pywikibot.output(u'Adding {0!s}'.format(catpl.title(asLink=True)))
             cats.append(catpl)
             text = textlib.replaceCategoryLinks(text, cats,
                                                 site=self.current_page.site)
@@ -386,8 +379,7 @@ class CategoryAddBot(MultipleSitesBot):
                 self.userPut(self.current_page, old_text, text,
                              summary=comment, minor=True, botflag=True)
             except pywikibot.PageSaveRelatedError as error:
-                pywikibot.output(u'Page %s not saved: %s'
-                                 % (self.current_page.title(asLink=True),
+                pywikibot.output(u'Page {0!s} not saved: {1!s}'.format(self.current_page.title(asLink=True),
                                     error))
 
 
@@ -657,7 +649,7 @@ class CategoryMoveRobot(object):
         Do not use this function from outside the class.
         """
         # Some preparing
-        pywikibot.output('Moving text from %s to %s.' % (
+        pywikibot.output('Moving text from {0!s} to {1!s}.'.format(
                          self.oldcat.title(), self.newcat.title()))
         comma = self.site.mediawiki_message('comma-separator')
         authors = comma.join(self.oldcat.contributingUsers())
@@ -682,7 +674,7 @@ class CategoryMoveRobot(object):
         # Remove all language-specified, non substed CFD templates
         site_templates = i18n.translate(self.site, cfd_templates) or ()
         for template_name in site_templates:
-            match = re.compile(r"{{%s.*?}}" % template_name, re.IGNORECASE)
+            match = re.compile(r"{{{{{0!s}.*?}}}}".format(template_name), re.IGNORECASE)
             self.newcat.text = match.sub('', self.newcat.text)
         # Remove leading whitespace
         self.newcat.text = self.newcat.text.lstrip()
@@ -727,7 +719,7 @@ class CategoryMoveRobot(object):
         history = self.oldcat.getVersionHistoryTable()
         title = i18n.twtranslate(self.site, 'category-section-title',
                                  {'oldcat': self.oldcat.title()})
-        self.newtalk.text = "%s\n== %s ==\n%s" % (self.newtalk.text,
+        self.newtalk.text = "{0!s}\n== {1!s} ==\n{2!s}".format(self.newtalk.text,
                                                   title, history)
         comment = i18n.twtranslate(self.site, 'category-version-history',
                                    {'oldcat': self.oldcat.title()})
@@ -810,21 +802,18 @@ class CategoryListifyRobot(object):
             if (not article.isImage() or
                     self.showImages) and not article.isCategory():
                 if self.talkPages and not article.isTalkPage():
-                    listString += "*[[%s]] -- [[%s|talk]]\n" \
-                                  % (article.title(),
+                    listString += "*[[{0!s}]] -- [[{1!s}|talk]]\n".format(article.title(),
                                      article.toggleTalkPage().title())
                 else:
-                    listString += "*[[%s]]\n" % article.title()
+                    listString += "*[[{0!s}]]\n".format(article.title())
             else:
                 if self.talkPages and not article.isTalkPage():
-                    listString += "*[[:%s]] -- [[%s|talk]]\n" \
-                                  % (article.title(),
+                    listString += "*[[:{0!s}]] -- [[{1!s}|talk]]\n".format(article.title(),
                                      article.toggleTalkPage().title())
                 else:
-                    listString += "*[[:%s]]\n" % article.title()
+                    listString += "*[[:{0!s}]]\n".format(article.title())
         if self.list.exists() and not self.overwrite:
-            pywikibot.output(u'Page %s already exists, aborting.'
-                             % self.list.title())
+            pywikibot.output(u'Page {0!s} already exists, aborting.'.format(self.list.title()))
         else:
             self.list.put(listString, summary=self.editSummary)
 
@@ -896,7 +885,7 @@ class CategoryTidyRobot(pywikibot.Bot):
                     pywikibot.output('')
                     pywikibot.output('Original categories: ')
                     for cat in article.categories():
-                        pywikibot.output(u'* %s' % cat.title())
+                        pywikibot.output(u'* {0!s}'.format(cat.title()))
 
         pywikibot.output(u'')
         # Show the title of the page where the link was found.
@@ -910,7 +899,7 @@ class CategoryTidyRobot(pywikibot.Bot):
         try:
             full_text = article.get(get_redirect=True)
         except pywikibot.NoPage:
-            pywikibot.output(u'Page %s not found.' % article.title())
+            pywikibot.output(u'Page {0!s} not found.'.format(article.title()))
             return
         try:
             contextLength = full_text.index('\n\n')
@@ -936,10 +925,10 @@ class CategoryTidyRobot(pywikibot.Bot):
         # show subcategories as possible choices (with numbers)
         for i, supercat in enumerate(supercatlist):
             # layout: we don't expect a cat to have more than 10 supercats
-            pywikibot.output(u'u%d - Move up to %s' % (i, supercat.title()))
+            pywikibot.output(u'u{0:d} - Move up to {1!s}'.format(i, supercat.title()))
         for i, subcat in enumerate(subcatlist):
             # layout: we don't expect a cat to have more than 100 subcats
-            pywikibot.output(u'%2d - Move down to %s' % (i, subcat.title()))
+            pywikibot.output(u'{0:2d} - Move down to {1!s}'.format(i, subcat.title()))
         options = (IntegerOption(0, len(supercatlist), 'u'),
                    IntegerOption(0, len(subcatlist)),
                    StandardOption('jump to another category', 'j'),
@@ -950,7 +939,7 @@ class CategoryTidyRobot(pywikibot.Bot):
         choice = pywikibot.input_choice('Choice:', options, default='c')
 
         if choice == 'c':
-            pywikibot.output(u'Saving category as %s' % current_cat.title())
+            pywikibot.output(u'Saving category as {0!s}'.format(current_cat.title()))
             if current_cat == original_cat:
                 pywikibot.output('No changes necessary.')
             else:
@@ -982,8 +971,7 @@ class CategoryTidyRobot(pywikibot.Bot):
         """Start bot."""
         super(CategoryTidyRobot, self).run()
         if not self._treat_counter:
-            pywikibot.output(u'There are no articles or files in category %s'
-                             % self.catTitle)
+            pywikibot.output(u'There are no articles or files in category {0!s}'.format(self.catTitle))
 
     def treat(self, page):
         """Process page."""
@@ -1032,7 +1020,7 @@ class CategoryTreeRobot(object):
         if currentDepth > 0:
             result += u' '
         result += cat.title(asLink=True, textlink=True, withNamespace=False)
-        result += ' (%d)' % cat.categoryinfo['pages']
+        result += ' ({0:d})'.format(cat.categoryinfo['pages'])
         if currentDepth < self.maxDepth // 2:
             # noisy dots
             pywikibot.output('.', newline=False)
@@ -1077,7 +1065,7 @@ class CategoryTreeRobot(object):
         tree = self.treeview(cat)
         pywikibot.output(u'')
         if self.filename:
-            pywikibot.output(u'Saving results in %s' % self.filename)
+            pywikibot.output(u'Saving results in {0!s}'.format(self.filename))
             f = codecs.open(self.filename, 'a', 'utf-8')
             f.write(tree)
             f.close()

--- a/scripts/cfd.py
+++ b/scripts/cfd.py
@@ -121,7 +121,7 @@ def main(*args):
             day = "None"
         elif m.check(dateheader, line):
             day = m.result.group(1)
-            pywikibot.output("Found day header: %s" % day)
+            pywikibot.output("Found day header: {0!s}".format(day))
         elif m.check(movecat, line):
             src = m.result.group(1)
             dest = m.result.group(2)
@@ -212,8 +212,7 @@ def findDay(pageTitle, oldDay):
                     elif paramName == 'year':
                         year = paramVal
                 if day and month and year:
-                    return ('[[Wikipedia:Categories for discussion/Log/%s %s %s]]'
-                            % (year, month, day))
+                    return ('[[Wikipedia:Categories for discussion/Log/{0!s} {1!s} {2!s}]]'.format(year, month, day))
         return oldDay
 
 if __name__ == "__main__":

--- a/scripts/checkimages.py
+++ b/scripts/checkimages.py
@@ -529,9 +529,9 @@ class LogIsFull(pywikibot.Error):
 def printWithTimeZone(message):
     """Print the messages followed by the TimeZone encoded correctly."""
     if message[-1] != ' ':
-        message = u'%s ' % message
+        message = u'{0!s} '.format(message)
     time_zone = time.strftime(u"%d %b %Y %H:%M:%S (UTC)", time.gmtime())
-    pywikibot.output(u"%s%s" % (message, time_zone))
+    pywikibot.output(u"{0!s}{1!s}".format(message, time_zone))
 
 
 class checkImagesBot(object):
@@ -673,7 +673,7 @@ class checkImagesBot(object):
         try:
             reportPageText = reportPageObject.get()
         except pywikibot.NoPage:
-            pywikibot.output(u'%s has been deleted...' % self.imageName)
+            pywikibot.output(u'{0!s} has been deleted...'.format(self.imageName))
             return
         # You can use this function also to find only the user that
         # has upload the image (FixME: Rewrite a bit this part)
@@ -695,8 +695,7 @@ class checkImagesBot(object):
                 nick = reportPageObject.latest_file_info.user
         except pywikibot.PageRelatedError:
             pywikibot.output(
-                u"Seems that %s has only the description and not the file..."
-                % self.image_to_report)
+                u"Seems that {0!s} has only the description and not the file...".format(self.image_to_report))
             repme = "\n* [[:File:%s]] problems '''with the APIs'''"
             self.report_image(self.image_to_report, self.rep_page, self.com,
                               repme)
@@ -732,8 +731,7 @@ class checkImagesBot(object):
             history = self.talk_page.getLatestEditors(limit=10)
             latest_user = history[0]["user"]
             pywikibot.output(
-                u'The latest user that has written something is: %s'
-                % latest_user)
+                u'The latest user that has written something is: {0!s}'.format(latest_user))
             if latest_user in self.bots:
                 second_text = True
                 # A block to prevent the second message if the bot also
@@ -759,7 +757,7 @@ class checkImagesBot(object):
             commentox = commento2
 
         if second_text:
-            newText = u"%s\n\n%s" % (testoattuale, self.notification2)
+            newText = u"{0!s}\n\n{1!s}".format(testoattuale, self.notification2)
         else:
             newText = '{0}\n\n== {1} ==\n{2}'.format(testoattuale, self.head,
                                                      self.notification)
@@ -776,8 +774,7 @@ class checkImagesBot(object):
             except (pywikibot.NoPage, pywikibot.IsRedirectPage):
                 return
             if self.sendemailActive:
-                text_to_send = re.sub(r'__user-nickname__', r'%s'
-                                      % self.luser, emailText)
+                text_to_send = re.sub(r'__user-nickname__', r'{0!s}'.format(self.luser), emailText)
                 emailClass = pywikibot.User(self.site, self.luser)
                 try:
                     emailClass.send_email(emailSubj, text_to_send)
@@ -787,7 +784,7 @@ class checkImagesBot(object):
 
     def regexGenerator(self, regexp, textrun):
         """Find page to yield using regex to parse text."""
-        regex = re.compile(r'%s' % regexp, re.UNICODE | re.DOTALL)
+        regex = re.compile(r'{0!s}'.format(regexp), re.UNICODE | re.DOTALL)
         results = regex.findall(textrun)
         for image in results:
             yield pywikibot.FilePage(self.site, image)
@@ -798,7 +795,7 @@ class checkImagesBot(object):
         # whitelist template...
         for langK in Family.load('wikipedia').langs.keys():
             self.hiddentemplates.add(pywikibot.Page(self.site,
-                                                    u'Template:%s' % langK))
+                                                    u'Template:{0!s}'.format(langK)))
         # Hidden template loading
         if self.pageHidden:
             try:
@@ -850,8 +847,7 @@ class checkImagesBot(object):
 
     def checkImageOnCommons(self):
         """Checking if the file is on commons."""
-        pywikibot.output(u'Checking if [[%s]] is on commons...'
-                         % self.imageName)
+        pywikibot.output(u'Checking if [[{0!s}]] is on commons...'.format(self.imageName))
         try:
             hash_found = self.image.latest_file_info.sha1
         except pywikibot.NoPage:
@@ -868,11 +864,10 @@ class checkImagesBot(object):
                     if pywikibot.Page(self.site,
                                       template) in templatesInTheImage:
                         pywikibot.output(
-                            u"%s is on commons but it's a service image."
-                            % self.imageName)
+                            u"{0!s} is on commons but it's a service image.".format(self.imageName))
                         return True  # continue with the check-part
 
-            pywikibot.output(u'%s is on commons!' % self.imageName)
+            pywikibot.output(u'{0!s} is on commons!'.format(self.imageName))
             if self.image.fileIsShared():
                 pywikibot.output(
                     u"But, the file doesn't exist on your project! Skip...")
@@ -884,8 +879,7 @@ class checkImagesBot(object):
             if re.findall(r'\bstemma\b', self.imageName.lower()) and \
                self.site.code == 'it':
                 pywikibot.output(
-                    u'%s has "stemma" inside, means that it\'s ok.'
-                    % self.imageName)
+                    u'{0!s} has "stemma" inside, means that it\'s ok.'.format(self.imageName))
                 return True
 
             # It's not only on commons but the image needs a check
@@ -964,10 +958,9 @@ class checkImagesBot(object):
                     if not (re.findall(dupRegex, DupPageText) or
                             re.findall(dupRegex, older_page_text)):
                         pywikibot.output(
-                            u'%s is a duplicate and has to be tagged...'
-                            % duplicate)
+                            u'{0!s} is a duplicate and has to be tagged...'.format(duplicate))
                         images_to_tag_list.append(duplicate)
-                        string += u"*[[:%s%s]]\n" % (self.image_namespace,
+                        string += u"*[[:{0!s}{1!s}]]\n".format(self.image_namespace,
                                                      duplicate)
                     else:
                         pywikibot.output(
@@ -975,7 +968,7 @@ class checkImagesBot(object):
                             u" or in the dupe's page. Skip.")
                         return  # Ok - Let's continue the checking phase
 
-                older_image_ns = u'%s%s' % (self.image_namespace, older_image)
+                older_image_ns = u'{0!s}{1!s}'.format(self.image_namespace, older_image)
 
                 # true if the image are not to be tagged as dupes
                 only_report = False
@@ -983,12 +976,11 @@ class checkImagesBot(object):
                 # put only one image or the whole list according to the request
                 if u'__images__' in dupText:
                     text_for_the_report = re.sub(r'__images__',
-                                                 r'\n%s*[[:%s]]\n'
-                                                 % (string, older_image_ns),
+                                                 r'\n{0!s}*[[:{1!s}]]\n'.format(string, older_image_ns),
                                                  dupText)
                 else:
                     text_for_the_report = re.sub(r'__image__',
-                                                 r'%s' % older_image_ns,
+                                                 r'{0!s}'.format(older_image_ns),
                                                  dupText)
 
                 # Two iteration: report the "problem" to the user only once
@@ -1004,8 +996,7 @@ class checkImagesBot(object):
                             break
                         # Delete the image in the list where we're write on
                         text_for_the_report = re.sub(
-                            r'\n\*\[\[:%s\]\]'
-                            % re.escape(self.image_namespace + image_to_tag),
+                            r'\n\*\[\[:{0!s}\]\]'.format(re.escape(self.image_namespace + image_to_tag)),
                             '', text_for_the_report)
                         self.report(text_for_the_report, image_to_tag,
                                     commImage=dupComment_image, unver=True)
@@ -1013,8 +1004,7 @@ class checkImagesBot(object):
                 if len(images_to_tag_list) != 0 and not only_report:
                     fp = pywikibot.FilePage(self.site, images_to_tag_list[-1])
                     already_reported_in_past = fp.revision_count(self.bots)
-                    from_regex = (r'\n\*\[\[:File:%s\]\]'
-                                  % re.escape(self.image.title(asUrl=True)))
+                    from_regex = (r'\n\*\[\[:File:{0!s}\]\]'.format(re.escape(self.image.title(asUrl=True))))
                     # Delete the image in the list where we're write on
                     text_for_the_report = re.sub(from_regex, '',
                                                  text_for_the_report)
@@ -1034,14 +1024,13 @@ class checkImagesBot(object):
                              "('''forced mode'''):"
                              % self.image.title(asUrl=True))
                 else:
-                    repme = ('\n* [[:File:%s]] has the following duplicates:'
-                             % self.image.title(asUrl=True))
+                    repme = ('\n* [[:File:{0!s}]] has the following duplicates:'.format(self.image.title(asUrl=True)))
 
                 for dup_page in duplicates:
                     if dup_page.title(asUrl=True) == self.image.title(asUrl=True):
                         # the image itself, not report also this as duplicate
                         continue
-                    repme += '\n** [[:File:%s]]' % dup_page.title(asUrl=True)
+                    repme += '\n** [[:File:{0!s}]]'.format(dup_page.title(asUrl=True))
 
                 result = self.report_image(self.imageName, self.rep_page,
                                            self.com, repme, addings=False)
@@ -1087,8 +1076,7 @@ class checkImagesBot(object):
         reported = True
         # Skip if the message is already there.
         if short_text in text_get:
-            pywikibot.output(u"%s is already in the report page."
-                             % image_to_report)
+            pywikibot.output(u"{0!s} is already in the report page.".format(image_to_report))
             reported = False
         elif len(text_get) >= self.logFulNumber:
             if self.logFullError:
@@ -1304,8 +1292,7 @@ class checkImagesBot(object):
                 pywikibot.output(u'File already fixed. Skipping.')
             else:
                 pywikibot.output(
-                    u"The file's description for %s contains %s..."
-                    % (self.imageName, self.name_used))
+                    u"The file's description for {0!s} contains {1!s}...".format(self.imageName, self.name_used))
                 if self.mex_used.lower() == 'default':
                     self.mex_used = self.unvertext
                 if self.imagestatus_used:
@@ -1321,19 +1308,15 @@ class checkImagesBot(object):
                 self.some_problem = False
         else:
             if not self.seems_ok and self.license_found:
-                rep_text_license_fake = u"\n* [[:File:%s]] seems to have " \
-                                        % self.imageName + \
-                    "a ''fake license'', license detected: <nowiki>%s</nowiki>" \
-                                        % self.license_found
+                rep_text_license_fake = u"\n* [[:File:{0!s}]] seems to have ".format(self.imageName) + \
+                    "a ''fake license'', license detected: <nowiki>{0!s}</nowiki>".format(self.license_found)
                 printWithTimeZone(
-                    u"%s seems to have a fake license: %s, reporting..."
-                    % (self.imageName, self.license_found))
+                    u"{0!s} seems to have a fake license: {1!s}, reporting...".format(self.imageName, self.license_found))
                 self.report_image(self.imageName,
                                   rep_text=rep_text_license_fake,
                                   addings=False)
             elif self.license_found:
-                pywikibot.output(u"[[%s]] seems ok, license found: {{%s}}..."
-                                 % (self.imageName, self.license_found))
+                pywikibot.output(u"[[{0!s}]] seems ok, license found: {{{{{1!s}}}}}...".format(self.imageName, self.license_found))
         return (self.license_found, self.whiteTemplatesFound)
 
     def load(self, raw):
@@ -1367,7 +1350,7 @@ class checkImagesBot(object):
                     {'num': skip_number}))
         # If we still have pages to skip:
         if len(self.skip_list) < skip_number:
-            pywikibot.output(u'Skipping %s...' % self.imageName)
+            pywikibot.output(u'Skipping {0!s}...'.format(self.imageName))
             self.skip_list.append(self.imageName)
             if skip_number == 1:
                 pywikibot.output('')
@@ -1383,8 +1366,7 @@ class checkImagesBot(object):
         Let the users to fix the image's problem alone in the first x seconds.
         """
         printWithTimeZone(
-            u'Skipping the files uploaded less than %s seconds ago..'
-            % wait_time)
+            u'Skipping the files uploaded less than {0!s} seconds ago..'.format(wait_time))
         for page in generator:
             image = pywikibot.FilePage(page)
             try:
@@ -1397,10 +1379,9 @@ class checkImagesBot(object):
                 yield image
             else:
                 pywikibot.warning(
-                    u'Skipping %s, uploaded %d %s ago..'
-                    % ((image.title(), delta.days, 'days')
+                    u'Skipping {0!s}, uploaded {1:d} {2!s} ago..'.format(*((image.title(), delta.days, 'days')
                        if delta.days > 0
-                       else (image.title(), delta.seconds, 'seconds')))
+                       else (image.title(), delta.seconds, 'seconds'))))
 
     def isTagged(self):
         """Understand if a file is already tagged or not."""
@@ -1410,8 +1391,7 @@ class checkImagesBot(object):
             # If there are {{ use regex, otherwise no (if there's not the
             # {{ may not be a template and the regex will be wrong)
             if '{{' in i:
-                regexP = re.compile(r'\{\{(?:template)?%s ?(?:\||\r?\n|\}|<|/) ?'
-                                    % i.split('{{')[1].replace(u' ', u'[ _]'),
+                regexP = re.compile(r'\{{\{{(?:template)?{0!s} ?(?:\||\r?\n|\}}|<|/) ?'.format(i.split('{{')[1].replace(u' ', u'[ _]')),
                                     re.I)
                 result = regexP.findall(self.imageCheckText)
                 if result:
@@ -1444,7 +1424,7 @@ class checkImagesBot(object):
             mexCatched = tupla[8]
             for k in find_list:
                 if find_tipe.lower() == 'findonly':
-                    searchResults = re.findall(r'%s' % k.lower(),
+                    searchResults = re.findall(r'{0!s}'.format(k.lower()),
                                                self.imageCheckText.lower())
                     if searchResults:
                         if searchResults[0] == self.imageCheckText.lower():
@@ -1457,7 +1437,7 @@ class checkImagesBot(object):
                             self.mex_used = mexCatched
                             break
                 elif find_tipe.lower() == 'find':
-                    if re.findall(r'%s' % k.lower(),
+                    if re.findall(r'{0!s}'.format(k.lower()),
                                   self.imageCheckText.lower()):
                         self.some_problem = True
                         self.text_used = text
@@ -1505,12 +1485,10 @@ class checkImagesBot(object):
         try:
             self.imageCheckText = self.image.get()
         except pywikibot.NoPage:
-            pywikibot.output(u"Skipping %s because it has been deleted."
-                             % self.imageName)
+            pywikibot.output(u"Skipping {0!s} because it has been deleted.".format(self.imageName))
             return
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u"Skipping %s because it's a redirect."
-                             % self.imageName)
+            pywikibot.output(u"Skipping {0!s} because it's a redirect.".format(self.imageName))
             return
         # Delete the fields where the templates cannot be loaded
         regex_nowiki = re.compile(r'<nowiki>(.*?)</nowiki>', re.DOTALL)
@@ -1520,7 +1498,7 @@ class checkImagesBot(object):
         # Deleting the useless template from the description (before adding sth
         # in the image the original text will be reloaded, don't worry).
         if self.isTagged():
-            printWithTimeZone(u'%s is already tagged...' % self.imageName)
+            printWithTimeZone(u'{0!s} is already tagged...'.format(self.imageName))
             return
 
         # something is the array with {{, MIT License and so on.
@@ -1536,7 +1514,7 @@ class checkImagesBot(object):
         if brackets and license_found:
             return
         elif delete:
-            pywikibot.output(u"%s is not a file!" % self.imageName)
+            pywikibot.output(u"{0!s} is not a file!".format(self.imageName))
             if not di:
                 pywikibot.output('No localized message given for '
                                  "'delete_immediately'. Skipping.")
@@ -1565,8 +1543,7 @@ class checkImagesBot(object):
                         smwl)
             return
         else:
-            pywikibot.output(u"%s has only text and not the specific license..."
-                             % self.imageName)
+            pywikibot.output(u"{0!s} has only text and not the specific license...".format(self.imageName))
             if hiddenTemplateFound and HiddenTN:
                 notification = HiddenTN % self.imageName
             elif nn:
@@ -1691,7 +1668,7 @@ def main(*args):
             elif len(arg) > 4:
                 catName = str(arg[5:])
             catSelected = pywikibot.Category(pywikibot.Site(),
-                                             'Category:%s' % catName)
+                                             'Category:{0!s}'.format(catName))
             generator = catSelected.articles(namespaces=[6])
             repeat = False
         elif arg.startswith('-ref'):
@@ -1722,8 +1699,7 @@ def main(*args):
         if limit == 1:
             pywikibot.output(u"Retrieving the latest file for checking...")
         else:
-            pywikibot.output(u"Retrieving the latest %d files for checking..."
-                             % limit)
+            pywikibot.output(u"Retrieving the latest {0:d} files for checking...".format(limit))
     while True:
         # Defing the Main Class.
         Bot = checkImagesBot(site, sendemailActive=sendemailActive,
@@ -1740,7 +1716,7 @@ def main(*args):
             try:
                 textRegex = pageRegex.get()
             except pywikibot.NoPage:
-                pywikibot.output(u"%s doesn't exist!" % pageRegex.title())
+                pywikibot.output(u"{0!s} doesn't exist!".format(pageRegex.title()))
                 textRegex = ''  # No source, so the bot will quit later.
         # If generator is the regex' one, use your own Generator using an url
         # or page and a regex.
@@ -1768,7 +1744,7 @@ def main(*args):
             Bot.checkStep()
 
         if repeat:
-            pywikibot.output(u"Waiting for %s seconds," % time_sleep)
+            pywikibot.output(u"Waiting for {0!s} seconds,".format(time_sleep))
             pywikibot.stopme()
             time.sleep(time_sleep)
         else:
@@ -1785,4 +1761,4 @@ if __name__ == "__main__":
         if ret is not False:
             final = time.time()
             delta = int(final - start)
-            pywikibot.output("Execution time: %s seconds\n" % delta)
+            pywikibot.output("Execution time: {0!s} seconds\n".format(delta))

--- a/scripts/claimit.py
+++ b/scripts/claimit.py
@@ -89,7 +89,7 @@ class ClaimRobot(WikidataBot):
         self.exists_arg = exists_arg
         self.cacheSources()
         if self.exists_arg:
-            pywikibot.output('\'exists\' argument set to \'%s\'' % self.exists_arg)
+            pywikibot.output('\'exists\' argument set to \'{0!s}\''.format(self.exists_arg))
 
     def treat(self, page, item):
         """Treat each page."""
@@ -119,16 +119,14 @@ class ClaimRobot(WikidataBot):
                             if (claim.getTarget() == existing.getTarget() and
                                     't' not in self.exists_arg):
                                 pywikibot.log(
-                                    'Skipping %s because claim with same target already exists'
-                                    % (claim.getID(),))
+                                    'Skipping {0!s} because claim with same target already exists'.format(claim.getID()))
                                 pywikibot.log(
                                     'Append \'t\' to -exists argument to override this behavior')
                                 break
                             if (listsEqual(claim.getSources(), existing.getSources()) and
                                     's' not in self.exists_arg):
                                 pywikibot.log(
-                                    'Skipping %s because claim with same sources already exists'
-                                    % (claim.getID(),))
+                                    'Skipping {0!s} because claim with same sources already exists'.format(claim.getID()))
                                 pywikibot.log(
                                     'Append \'s\' to -exists argument to override this behavior')
                                 break
@@ -142,8 +140,7 @@ class ClaimRobot(WikidataBot):
                                 break
                             skip = False
                 if not skip:
-                    pywikibot.output('Adding %s --> %s'
-                                     % (claim.getID(), claim.getTarget()))
+                    pywikibot.output('Adding {0!s} --> {1!s}'.format(claim.getID(), claim.getTarget()))
                     item.addClaim(claim)
                     # A generator might yield pages from multiple languages
                     source = self.getSource(page.site)
@@ -214,8 +211,7 @@ def main(*args):
             target = pywikibot.Coordinate(coord_args[0], coord_args[1], precision=precision)
         else:
             raise NotImplementedError(
-                "%s datatype is not yet supported by claimit.py"
-                % claim.type)
+                "{0!s} datatype is not yet supported by claimit.py".format(claim.type))
         claim.setTarget(target)
         claims.append(claim)
 

--- a/scripts/clean_sandbox.py
+++ b/scripts/clean_sandbox.py
@@ -187,12 +187,10 @@ class SandboxBot(Bot):
             wait = False
             now = time.strftime("%d %b %Y %H:%M:%S (UTC)", time.gmtime())
             for sandboxPage in self.generator:
-                pywikibot.output(u'Preparing to process sandbox page %s'
-                                 % sandboxPage.title(asLink=True))
+                pywikibot.output(u'Preparing to process sandbox page {0!s}'.format(sandboxPage.title(asLink=True)))
                 if sandboxPage.isRedirectPage():
                     pywikibot.warning(
-                        u'%s is a redirect page, cleaning it anyway'
-                        % sandboxPage.title(asLink=True))
+                        u'{0!s} is a redirect page, cleaning it anyway'.format(sandboxPage.title(asLink=True)))
                 try:
                     text = sandboxPage.text
                     if not self.getOption('text'):
@@ -229,10 +227,8 @@ class SandboxBot(Bot):
                                              u'sandbox cleaned.')
                         else:  # wait for the rest
                             pywikibot.output(
-                                u'Sandbox edited %.1f minutes ago...'
-                                % (edit_delta.seconds / 60.0))
-                            pywikibot.output(u'Sleeping for %d minutes.'
-                                             % (delta.seconds // 60))
+                                u'Sandbox edited {0:.1f} minutes ago...'.format((edit_delta.seconds / 60.0)))
+                            pywikibot.output(u'Sleeping for {0:d} minutes.'.format((delta.seconds // 60)))
                             time.sleep(delta.seconds)
                             wait = True
                 except pywikibot.EditConflict:
@@ -247,11 +243,9 @@ class SandboxBot(Bot):
                 return
             elif not wait:
                 if self.getOption('hours') < 1.0:
-                    pywikibot.output('\nSleeping %s minutes, now %s'
-                                     % ((self.getOption('hours') * 60), now))
+                    pywikibot.output('\nSleeping {0!s} minutes, now {1!s}'.format((self.getOption('hours') * 60), now))
                 else:
-                    pywikibot.output('\nSleeping %s hours, now %s'
-                                     % (self.getOption('hours'), now))
+                    pywikibot.output('\nSleeping {0!s} hours, now {1!s}'.format(self.getOption('hours'), now))
                 time.sleep(self.getOption('hours') * 60 * 60)
 
 

--- a/scripts/commons_link.py
+++ b/scripts/commons_link.py
@@ -83,37 +83,31 @@ class CommonsLinkBot(Bot):
 
                         # for Commons/Commonscat template
                         s = self.findTemplate.search(text)
-                        s2 = getattr(self, 'findTemplate%d'
-                                           % (2, 3)[catmode]).search(text)
+                        s2 = getattr(self, 'findTemplate{0:d}'.format((2, 3)[catmode])).search(text)
                         if s or s2:
                             pywikibot.output(u'** Already done.')
                         else:
                             cats = textlib.getCategoryLinks(text, site=page.site)
                             text = textlib.replaceCategoryLinks(
-                                u'%s{{commons%s|%s}}'
-                                % (text, ('', 'cat')[catmode], pagetitle),
+                                u'{0!s}{{{{commons{1!s}|{2!s}}}}}'.format(text, ('', 'cat')[catmode], pagetitle),
                                 cats, site=page.site)
                             comment = i18n.twtranslate(page.site,
-                                                       'commons_link%s-template-added'
-                                                       % ('', '-cat')[catmode])
+                                                       'commons_link{0!s}-template-added'.format(('', '-cat')[catmode]))
                             try:
                                 self.userPut(page, oldText, text, summary=comment)
                             except pywikibot.EditConflict:
                                 pywikibot.output(
-                                    u'Skipping %s because of edit conflict'
-                                    % page.title())
+                                    u'Skipping {0!s} because of edit conflict'.format(page.title()))
 
                 except pywikibot.NoPage:
-                    pywikibot.output(u'%s does not exist in Commons'
-                                     % page.__class__.__name__)
+                    pywikibot.output(u'{0!s} does not exist in Commons'.format(page.__class__.__name__))
 
             except pywikibot.NoPage:
-                pywikibot.output(u'Page %s does not exist' % page.title())
+                pywikibot.output(u'Page {0!s} does not exist'.format(page.title()))
             except pywikibot.IsRedirectPage:
-                pywikibot.output(u'Page %s is a redirect; skipping.'
-                                 % page.title())
+                pywikibot.output(u'Page {0!s} is a redirect; skipping.'.format(page.title()))
             except pywikibot.LockedPage:
-                pywikibot.output(u'Page %s is locked' % page.title())
+                pywikibot.output(u'Page {0!s} is locked'.format(page.title()))
 
 
 def main(*args):

--- a/scripts/commonscat.py
+++ b/scripts/commonscat.py
@@ -238,17 +238,13 @@ class CommonscatBot(Bot):
     def treat(self, page):
         """Load the given page, do some changes, and save it."""
         if not page.exists():
-            pywikibot.output(u'Page %s does not exist. Skipping.'
-                             % page.title(asLink=True))
+            pywikibot.output(u'Page {0!s} does not exist. Skipping.'.format(page.title(asLink=True)))
         elif page.isRedirectPage():
-            pywikibot.output(u'Page %s is a redirect. Skipping.'
-                             % page.title(asLink=True))
+            pywikibot.output(u'Page {0!s} is a redirect. Skipping.'.format(page.title(asLink=True)))
         elif page.isCategoryRedirect():
-            pywikibot.output(u'Page %s is a category redirect. Skipping.'
-                             % page.title(asLink=True))
+            pywikibot.output(u'Page {0!s} is a category redirect. Skipping.'.format(page.title(asLink=True)))
         elif page.isDisambig():
-            pywikibot.output(u'Page %s is a disambiguation. Skipping.'
-                             % page.title(asLink=True))
+            pywikibot.output(u'Page {0!s} is a disambiguation. Skipping.'.format(page.title(asLink=True)))
         else:
             self.addCommonscat(page)
 
@@ -296,16 +292,14 @@ class CommonscatBot(Bot):
             page.site.code)
         commonscatLink = self.getCommonscatLink(page)
         if commonscatLink:
-            pywikibot.output(u'Commonscat template is already on %s'
-                             % page.title())
+            pywikibot.output(u'Commonscat template is already on {0!s}'.format(page.title()))
             (currentCommonscatTemplate,
              currentCommonscatTarget, LinkText, Note) = commonscatLink
             checkedCommonscatTarget = self.checkCommonscatLink(
                 currentCommonscatTarget)
             if (currentCommonscatTarget == checkedCommonscatTarget):
                 # The current commonscat link is good
-                pywikibot.output(u'Commonscat link at %s to Category:%s is ok'
-                                 % (page.title(), currentCommonscatTarget))
+                pywikibot.output(u'Commonscat link at {0!s} to Category:{1!s} is ok'.format(page.title(), currentCommonscatTarget))
                 return True
             elif checkedCommonscatTarget != u'':
                 # We have a new Commonscat link, replace the old one
@@ -324,15 +318,14 @@ class CommonscatBot(Bot):
                 # TODO: if the commonsLink == u'', should it be removed?
 
         elif self.skipPage(page):
-            pywikibot.output("Found a template in the skip list. Skipping %s"
-                             % page.title())
+            pywikibot.output("Found a template in the skip list. Skipping {0!s}".format(page.title()))
         else:
             commonscatLink = self.findCommonscatLink(page)
             if (commonscatLink != u''):
                 if commonscatLink == page.title():
-                    textToAdd = u'{{%s}}' % primaryCommonscat
+                    textToAdd = u'{{{{{0!s}}}}}'.format(primaryCommonscat)
                 else:
-                    textToAdd = u'{{%s|%s}}' % (primaryCommonscat,
+                    textToAdd = u'{{{{{0!s}|{1!s}}}}}'.format(primaryCommonscat,
                                                 commonscatLink)
                 rv = add_text(page, textToAdd,
                               self.getOption('summary'),
@@ -351,19 +344,16 @@ class CommonscatBot(Bot):
                               oldcat.lower() in page.title().lower()):
             linktitle = oldcat
         if linktitle and newcat != page.title(withNamespace=False):
-            newtext = re.sub(u'(?i)\{\{%s\|?[^{}]*(?:\{\{.*\}\})?\}\}'
-                             % oldtemplate,
-                             u'{{%s|%s|%s}}' % (newtemplate, newcat, linktitle),
+            newtext = re.sub(u'(?i)\{{\{{{0!s}\|?[^{{}}]*(?:\{{\{{.*\}}\}})?\}}\}}'.format(oldtemplate),
+                             u'{{{{{0!s}|{1!s}|{2!s}}}}}'.format(newtemplate, newcat, linktitle),
                              page.get())
         elif newcat == page.title(withNamespace=False):
-            newtext = re.sub(u'(?i)\{\{%s\|?[^{}]*(?:\{\{.*\}\})?\}\}'
-                             % oldtemplate,
-                             u'{{%s}}' % newtemplate,
+            newtext = re.sub(u'(?i)\{{\{{{0!s}\|?[^{{}}]*(?:\{{\{{.*\}}\}})?\}}\}}'.format(oldtemplate),
+                             u'{{{{{0!s}}}}}'.format(newtemplate),
                              page.get())
         elif oldcat.strip() != newcat:  # strip trailing white space
-            newtext = re.sub(u'(?i)\{\{%s\|?[^{}]*(?:\{\{.*\}\})?\}\}'
-                             % oldtemplate,
-                             u'{{%s|%s}}' % (newtemplate, newcat),
+            newtext = re.sub(u'(?i)\{{\{{{0!s}\|?[^{{}}]*(?:\{{\{{.*\}}\}})?\}}\}}'.format(oldtemplate),
+                             u'{{{{{0!s}|{1!s}}}}}'.format(newtemplate, newcat),
                              page.get())
         else:  # nothing left to do
             return
@@ -387,7 +377,7 @@ class CommonscatBot(Bot):
         """
         for ipageLink in page.langlinks():
             ipage = pywikibot.page.Page(ipageLink)
-            pywikibot.log("Looking for template on %s" % (ipage.title()))
+            pywikibot.log("Looking for template on {0!s}".format((ipage.title())))
             try:
                 if (not ipage.exists() or ipage.isRedirectPage() or
                         ipage.isDisambig()):
@@ -400,8 +390,7 @@ class CommonscatBot(Bot):
                 checkedCommonscat = self.checkCommonscatLink(possibleCommonscat)
                 if (checkedCommonscat != u''):
                     pywikibot.output(
-                        u"Found link for %s at [[%s:%s]] to %s."
-                        % (page.title(), ipage.site.code,
+                        u"Found link for {0!s} at [[{1!s}:{2!s}]] to {3!s}.".format(page.title(), ipage.site.code,
                            ipage.title(), checkedCommonscat))
                     return checkedCommonscat
             except pywikibot.BadTitle:

--- a/scripts/coordinate_import.py
+++ b/scripts/coordinate_import.py
@@ -81,8 +81,7 @@ class CoordImportRobot(WikidataBot):
 
         claims = item.get().get('claims')
         if self.prop in claims:
-            pywikibot.output(u'Item %s already contains coordinates (%s)'
-                             % (item.title(), self.prop))
+            pywikibot.output(u'Item {0!s} already contains coordinates ({1!s})'.format(item.title(), self.prop))
             return
 
         prop = self.has_coord_qualifier(claims)
@@ -94,7 +93,7 @@ class CoordImportRobot(WikidataBot):
 
         newclaim = pywikibot.Claim(self.repo, self.prop)
         newclaim.setTarget(coordinate)
-        pywikibot.output(u'Adding %s, %s to %s' % (coordinate.lat,
+        pywikibot.output(u'Adding {0!s}, {1!s} to {2!s}'.format(coordinate.lat,
                                                    coordinate.lon,
                                                    item.title()))
         try:
@@ -104,7 +103,7 @@ class CoordImportRobot(WikidataBot):
             if source:
                 newclaim.addSource(source, bot=True)
         except CoordinateGlobeUnknownException as e:
-            pywikibot.output(u'Skipping unsupported globe: %s' % e.args)
+            pywikibot.output(u'Skipping unsupported globe: {0!s}'.format(e.args))
 
 
 def main(*args):

--- a/scripts/cosmetic_changes.py
+++ b/scripts/cosmetic_changes.py
@@ -80,11 +80,9 @@ class CosmeticChangesBot(MultipleSitesBot, ExistingPageBot, NoRedirectPageBot):
                                  summary=self.getOption('summary'),
                                  async=self.getOption('async'))
         except pywikibot.LockedPage:
-            pywikibot.output("Page %s is locked?!"
-                             % self.current_page.title(asLink=True))
+            pywikibot.output("Page {0!s} is locked?!".format(self.current_page.title(asLink=True)))
         except pywikibot.EditConflict:
-            pywikibot.output("An edit conflict has occurred at %s."
-                             % self.current_page.title(asLink=True))
+            pywikibot.output("An edit conflict has occurred at {0!s}.".format(self.current_page.title(asLink=True)))
 
 
 def main(*args):

--- a/scripts/create_categories.py
+++ b/scripts/create_categories.py
@@ -61,7 +61,7 @@ class CreateCategoriesBot(Bot):
         title = page.title(withNamespace=False)
 
         newpage = pywikibot.Category(pywikibot.Site('commons', 'commons'),
-                                     '%s %s' % (self.basename, title))
+                                     '{0!s} {1!s}'.format(self.basename, title))
         newtext = (u'[[Category:%(parent)s|%(title)s]]\n'
                    u'[[Category:%(title)s]]\n'
                    % {'parent': self.parent, 'title': title})
@@ -71,14 +71,14 @@ class CreateCategoriesBot(Bot):
             try:
                 self.userPut(newpage, '', newtext, summary=self.comment)
             except pywikibot.EditConflict:
-                pywikibot.output(u'Skipping %s due to edit conflict' % newpage.title())
+                pywikibot.output(u'Skipping {0!s} due to edit conflict'.format(newpage.title()))
             except pywikibot.ServerError:
-                pywikibot.output(u'Skipping %s due to server error' % newpage.title())
+                pywikibot.output(u'Skipping {0!s} due to server error'.format(newpage.title()))
             except pywikibot.PageNotSaved as error:
-                pywikibot.output(u'Error putting page: %s' % error.args)
+                pywikibot.output(u'Error putting page: {0!s}'.format(error.args))
         else:
             # FIXME: Add overwrite option
-            pywikibot.output(u'%s already exists, skipping' % newpage.title())
+            pywikibot.output(u'{0!s} already exists, skipping'.format(newpage.title()))
 
 
 def main(*args):

--- a/scripts/data_ingestion.py
+++ b/scripts/data_ingestion.py
@@ -131,12 +131,12 @@ class Photo(pywikibot.FilePage):
         params = {}
         params.update(self.metadata)
         params.update(extraparams)
-        description = u'{{%s\n' % template
+        description = u'{{{{{0!s}\n'.format(template)
         for key in sorted(params.keys()):
             value = params[key]
             if not key.startswith("_"):
                 description = description + (
-                    u'|%s=%s' % (key, self._safeTemplateValue(value))) + "\n"
+                    u'|{0!s}={1!s}'.format(key, self._safeTemplateValue(value))) + "\n"
         description = description + u'}}'
 
         return description
@@ -200,7 +200,7 @@ class DataIngestionBot(pywikibot.Bot):
         """Process each page."""
         duplicates = photo.findDuplicateImages()
         if duplicates:
-            pywikibot.output(u"Skipping duplicate of %r" % duplicates)
+            pywikibot.output(u"Skipping duplicate of {0!r}".format(duplicates))
             return duplicates[0]
 
         title = photo.getTitle(self.titlefmt)
@@ -285,7 +285,7 @@ def main(*args):
         try:
             config_page.get()
         except pywikibot.NoPage:
-            pywikibot.error('%s does not exist' % config_page)
+            pywikibot.error('{0!s} does not exist'.format(config_page))
             continue
 
         configuration = DataIngestionBot.parseConfigurationPage(config_page)
@@ -295,7 +295,7 @@ def main(*args):
 
             f = codecs.open(filename, 'r', configuration['csvEncoding'])
         except (IOError, OSError) as e:
-            pywikibot.error('%s could not be opened: %s' % (filename, e))
+            pywikibot.error('{0!s} could not be opened: {1!s}'.format(filename, e))
             continue
 
         try:

--- a/scripts/delete.py
+++ b/scripts/delete.py
@@ -154,8 +154,7 @@ def main(*args):
     # page generator to actually get the text of those pages.
     if generator:
         if summary is None:
-            summary = pywikibot.input(u'Enter a reason for the %sdeletion:'
-                                      % ['', 'un'][options.get('undelete', False)])
+            summary = pywikibot.input(u'Enter a reason for the {0!s}deletion:'.format(['', 'un'][options.get('undelete', False)]))
         bot = DeletionRobot(generator, summary, **options)
         bot.run()
         return True

--- a/scripts/djvutext.py
+++ b/scripts/djvutext.py
@@ -118,7 +118,7 @@ class DjVuTextBot(SingleSiteBot):
 
         summary = self.getOption('summary')
         if page.exists() and not self.getOption('force'):
-            pywikibot.output('Page %s already exists, not adding!' % page)
+            pywikibot.output('Page {0!s} already exists, not adding!'.format(page))
         else:
             self.userPut(page, old_text, new_text,
                          summary=summary, minor=True, botflag=True)
@@ -154,7 +154,7 @@ def main(*args):
         elif arg == '-always':
             options['always'] = True
         else:
-            pywikibot.output('Unknown argument %s' % arg)
+            pywikibot.output('Unknown argument {0!s}'.format(arg))
 
     # index is mandatory.
     if not index:
@@ -165,7 +165,7 @@ def main(*args):
     djvu_path = os.path.expanduser(djvu_path)
     djvu_path = os.path.abspath(djvu_path)
     if not os.path.exists(djvu_path):
-        pywikibot.error('No such file or directory: %s' % djvu_path)
+        pywikibot.error('No such file or directory: {0!s}'.format(djvu_path))
         return False
     if os.path.isdir(djvu_path):
         djvu_path = os.path.join(djvu_path, index)
@@ -174,7 +174,7 @@ def main(*args):
     djvu = DjVuFile(djvu_path)
 
     if not djvu.has_text():
-        pywikibot.error('No text layer in djvu file %s' % djvu.file_djvu)
+        pywikibot.error('No text layer in djvu file {0!s}'.format(djvu.file_djvu))
         return False
 
     # Parse pages param.
@@ -190,7 +190,7 @@ def main(*args):
 
     site = pywikibot.Site()
     if not site.has_extension('ProofreadPage'):
-        pywikibot.error('Site %s must have ProofreadPage extension.' % site)
+        pywikibot.error('Site {0!s} must have ProofreadPage extension.'.format(site))
         return False
 
     index_page = pywikibot.Page(site, index, ns=site.proofread_index_ns)
@@ -198,8 +198,7 @@ def main(*args):
     if not index_page.exists():
         raise pywikibot.NoPage(index)
 
-    pywikibot.output('uploading text from %s to %s'
-                     % (djvu.file_djvu, index_page.title(asLink=True)))
+    pywikibot.output('uploading text from {0!s} to {1!s}'.format(djvu.file_djvu, index_page.title(asLink=True)))
 
     bot = DjVuTextBot(djvu, index_page, pages, **options)
     bot.run()

--- a/scripts/fixing_redirects.py
+++ b/scripts/fixing_redirects.py
@@ -110,7 +110,7 @@ class FixingRedirectBot(SingleSiteBot, ExistingPageBot, NoRedirectPageBot,
                 new_page_title = new_page_title[1:]
 
             if (new_page_title == link_text and not section):
-                newlink = "[[%s]]" % new_page_title
+                newlink = "[[{0!s}]]".format(new_page_title)
             # check if we can create a link with trailing characters instead of a
             # pipelink
             elif (len(new_page_title) <= len(link_text) and
@@ -119,10 +119,10 @@ class FixingRedirectBot(SingleSiteBot, ExistingPageBot, NoRedirectPageBot,
                   re.sub(re.compile(linktrail), '',
                          link_text[len(new_page_title):]) == '' and
                   not section):
-                newlink = "[[%s]]%s" % (link_text[:len(new_page_title)],
+                newlink = "[[{0!s}]]{1!s}".format(link_text[:len(new_page_title)],
                                         link_text[len(new_page_title):])
             else:
-                newlink = "[[%s%s|%s]]" % (new_page_title, section, link_text)
+                newlink = "[[{0!s}{1!s}|{2!s}]]".format(new_page_title, section, link_text)
             text = text[:m.start()] + newlink + text[m.end():]
             continue
         return text

--- a/scripts/flickrripper.py
+++ b/scripts/flickrripper.py
@@ -171,7 +171,7 @@ def getFlinfoDescription(photo_id):
     parameters = urlencode({'id': photo_id, 'raw': 'on'})
 
     return fetch(
-        'http://wikipedia.ramselehof.de/flinfo.php?%s' % parameters).content
+        'http://wikipedia.ramselehof.de/flinfo.php?{0!s}'.format(parameters)).content
 
 
 def getFilename(photoInfo, site=None, project=u'Flickr'):
@@ -204,17 +204,16 @@ def getFilename(photoInfo, site=None, project=u'Flickr'):
             title = u''
             # Should probably have the id of the photo as last resort.
 
-    if pywikibot.Page(site, u'File:%s - %s - %s.jpg'
-                      % (title, project, username)).exists():
+    if pywikibot.Page(site, u'File:{0!s} - {1!s} - {2!s}.jpg'.format(title, project, username)).exists():
         i = 1
         while True:
-            name = '%s - %s - %s (%d).jpg' % (title, project, username, i)
+            name = '{0!s} - {1!s} - {2!s} ({3:d}).jpg'.format(title, project, username, i)
             if pywikibot.Page(site, 'File:' + name).exists():
                 i += 1
             else:
                 return name
     else:
-        return u'%s - %s - %s.jpg' % (title, project, username)
+        return u'{0!s} - {1!s} - {2!s}.jpg'.format(title, project, username)
 
 
 def cleanUpTitle(title):
@@ -251,7 +250,7 @@ def buildDescription(flinfoDescription=u'', flickrreview=False, reviewer=u'',
     The description is based on the info from flickrinfo and improved.
 
     """
-    description = u'== {{int:filedesc}} ==\n%s' % flinfoDescription
+    description = u'== {{{{int:filedesc}}}} ==\n{0!s}'.format(flinfoDescription)
     if removeCategories:
         description = textlib.removeCategoryLinks(description,
                                                   pywikibot.Site(
@@ -295,7 +294,7 @@ def processPhoto(flickr, photo_id=u'', flickrreview=False, reviewer=u'',
         # Don't upload duplicate images, should add override option
         duplicates = findDuplicateImages(photo)
         if duplicates:
-            pywikibot.output(u'Found duplicate image at %s' % duplicates.pop())
+            pywikibot.output(u'Found duplicate image at {0!s}'.format(duplicates.pop()))
         else:
             filename = getFilename(photoInfo)
             flinfoDescription = getFlinfoDescription(photo_id)

--- a/scripts/freebasemappingupload.py
+++ b/scripts/freebasemappingupload.py
@@ -40,8 +40,7 @@ class FreebaseMapperRobot(object):
         self.repo = pywikibot.Site('wikidata', 'wikidata').data_repository()
         self.filename = filename
         if not os.path.exists(self.filename):
-            pywikibot.output('Cannot find %s. Try providing the absolute path.'
-                             % self.filename)
+            pywikibot.output('Cannot find {0!s}. Try providing the absolute path.'.format(self.filename))
             sys.exit(1)
 
     def run(self):
@@ -83,15 +82,14 @@ class FreebaseMapperRobot(object):
         else:
             # Just pick up the first label
             label = list(data.labels.values())[0]
-        pywikibot.output('Parsed: %s <--> %s' % (qid, mid))
-        pywikibot.output('%s is %s' % (data.getID(), label))
+        pywikibot.output('Parsed: {0!s} <--> {1!s}'.format(qid, mid))
+        pywikibot.output('{0!s} is {1!s}'.format(data.getID(), label))
         if data.claims and 'P646' in data.claims:
             # We assume that there is only one claim.
             # If there are multiple ones, our logs might be wrong
             # but the constraint value reports will catch them
             if mid != data.claims['P646'][0].getTarget():
-                pywikibot.output('Mismatch: expected %s, has %s instead'
-                                 % (mid, data.claims['P646'][0].getTarget()))
+                pywikibot.output('Mismatch: expected {0!s}, has {1!s} instead'.format(mid, data.claims['P646'][0].getTarget()))
             else:
                 pywikibot.output('Already has mid set, is consistent.')
         else:

--- a/scripts/harvest_template.py
+++ b/scripts/harvest_template.py
@@ -83,7 +83,7 @@ class HarvestRobot(WikidataBot):
         """Fetch redirects of the title, so we can check against them."""
         temp = pywikibot.Page(pywikibot.Site(), title, ns=10)
         if not temp.exists():
-            pywikibot.error(u'Template %s does not exist.' % temp.title())
+            pywikibot.error(u'Template {0!s} does not exist.'.format(temp.title()))
             exit()
 
         # Put some output here since it can take a while
@@ -121,7 +121,7 @@ class HarvestRobot(WikidataBot):
             return
 
         if linked_item.title() == item.title():
-            pywikibot.output('%s links to itself. Skipping.' % (linked_page))
+            pywikibot.output('{0!s} links to itself. Skipping.'.format((linked_page)))
             return
 
         return linked_item
@@ -146,8 +146,7 @@ class HarvestRobot(WikidataBot):
                                           ns=10).title(withNamespace=False)
             except pywikibot.exceptions.InvalidTitle:
                 pywikibot.error(
-                    "Failed parsing template; '%s' should be the template name."
-                    % template)
+                    "Failed parsing template; '{0!s}' should be the template name.".format(template))
                 continue
             # We found the template we were looking for
             if template in self.templateTitles:
@@ -163,8 +162,7 @@ class HarvestRobot(WikidataBot):
                         claim = pywikibot.Claim(self.repo, self.fields[field])
                         if claim.getID() in item.get().get('claims'):
                             pywikibot.output(
-                                'A claim for %s already exists. Skipping.'
-                                % claim.getID())
+                                'A claim for {0!s} already exists. Skipping.'.format(claim.getID()))
                             # TODO: Implement smarter approach to merging
                             # harvested values with existing claims esp.
                             # without overwriting humans unintentionally.
@@ -196,18 +194,15 @@ class HarvestRobot(WikidataBot):
                                     image = pywikibot.FilePage(image.getRedirectTarget())
                                 if not image.exists():
                                     pywikibot.output(
-                                        '[[%s]] doesn\'t exist so I can\'t link to it'
-                                        % (image.title(),))
+                                        '[[{0!s}]] doesn\'t exist so I can\'t link to it'.format(image.title()))
                                     continue
                                 claim.setTarget(image)
                             else:
                                 pywikibot.output(
-                                    '%s is not a supported datatype.'
-                                    % claim.type)
+                                    '{0!s} is not a supported datatype.'.format(claim.type))
                                 continue
 
-                            pywikibot.output('Adding %s --> %s'
-                                             % (claim.getID(), claim.getTarget()))
+                            pywikibot.output('Adding {0!s} --> {1!s}'.format(claim.getID(), claim.getTarget()))
                             item.addClaim(claim)
                             # A generator might yield pages from multiple sites
                             source = self.getSource(page.site)

--- a/scripts/illustrate_wikidata.py
+++ b/scripts/illustrate_wikidata.py
@@ -50,14 +50,13 @@ class IllustrateRobot(WikidataBot):
 
         claim = pywikibot.Claim(self.repo, self.wdproperty)
         if claim.type != 'commonsMedia':
-            raise ValueError(u'%s is of type %s, should be commonsMedia'
-                             % (self.wdproperty, claim.type))
+            raise ValueError(u'{0!s} is of type {1!s}, should be commonsMedia'.format(self.wdproperty, claim.type))
 
     def treat(self, page, item):
         """Treat a page / item."""
         self.current_page = page
 
-        pywikibot.output(u'Found %s' % item.title())
+        pywikibot.output(u'Found {0!s}'.format(item.title()))
         imagename = page.properties().get('page_image')
 
         if not imagename:
@@ -65,8 +64,7 @@ class IllustrateRobot(WikidataBot):
 
         claims = item.get().get('claims')
         if self.wdproperty in claims:
-            pywikibot.output('Item %s already contains image (%s)'
-                             % (item.title(), self.wdproperty))
+            pywikibot.output('Item {0!s} already contains image ({1!s})'.format(item.title(), self.wdproperty))
             return
 
         newclaim = pywikibot.Claim(self.repo, self.wdproperty)
@@ -77,11 +75,11 @@ class IllustrateRobot(WikidataBot):
             image = pywikibot.FilePage(image.getRedirectTarget())
 
         if not image.exists():
-            pywikibot.output('[[%s]] doesn\'t exist so I can\'t link to it' % (image.title(),))
+            pywikibot.output('[[{0!s}]] doesn\'t exist so I can\'t link to it'.format(image.title()))
             return
 
         newclaim.setTarget(image)
-        pywikibot.output('Adding %s --> %s' % (newclaim.getID(), newclaim.getTarget()))
+        pywikibot.output('Adding {0!s} --> {1!s}'.format(newclaim.getID(), newclaim.getTarget()))
         item.addClaim(newclaim)
 
         # A generator might yield pages from multiple sites

--- a/scripts/image.py
+++ b/scripts/image.py
@@ -151,16 +151,14 @@ class ImageRobot(ReplaceBot):
         escaped = re.sub('\\\\[_ ]', '[_ ]', escaped)
         if not self.getOption('loose') or not self.new_image:
             image_regex = re.compile(
-                r'\[\[ *(?:%s)\s*:\s*%s *(?P<parameters>\|[^\n]+|) *\]\]'
-                % ('|'.join(namespace), escaped))
+                r'\[\[ *(?:{0!s})\s*:\s*{1!s} *(?P<parameters>\|[^\n]+|) *\]\]'.format('|'.join(namespace), escaped))
         else:
             image_regex = re.compile(r'' + escaped)
 
         if self.new_image:
             if not self.getOption('loose'):
                 replacements.append((image_regex,
-                                     u'[[%s:%s\\g<parameters>]]'
-                                     % (self.site.namespaces.FILE,
+                                     u'[[{0!s}:{1!s}\\g<parameters>]]'.format(self.site.namespaces.FILE,
                                         self.new_image)))
             else:
                 replacements.append((image_regex, self.new_image))

--- a/scripts/imagecopy.py
+++ b/scripts/imagecopy.py
@@ -412,7 +412,7 @@ class TkdialogIC(Tkdialog):
         # uploader.decode('utf-8')
         scrollbar = Tkinter.Scrollbar(self.root, orient=Tkinter.VERTICAL)
         label = Tkinter.Label(self.root, text=u"Enter new name or leave blank.")
-        imageinfo = Tkinter.Label(self.root, text='Uploaded by %s.' % uploader)
+        imageinfo = Tkinter.Label(self.root, text='Uploaded by {0!s}.'.format(uploader))
         textarea = Tkinter.Text(self.root)
         textarea.insert(Tkinter.END, content.encode('utf-8'))
         textarea.config(state=Tkinter.DISABLED,
@@ -539,7 +539,7 @@ def main(*args):
                     newname = imagepage.title(withNamespace=False)
                     CommonsPage = pywikibot.Page(pywikibot.Site('commons',
                                                                 'commons'),
-                                                 u'File:%s' % newname)
+                                                 u'File:{0!s}'.format(newname))
                     if CommonsPage.exists():
                         skip = True
                 else:

--- a/scripts/imagecopy_self.py
+++ b/scripts/imagecopy_self.py
@@ -351,8 +351,7 @@ class imageFetcher(threading.Thread):
             # First do autoskip.
             if self.doiskip(imagepage):
                 pywikibot.output(
-                    u'Skipping %s : Got a template on the skip list.'
-                    % page.title())
+                    u'Skipping {0!s} : Got a template on the skip list.'.format(page.title()))
                 return False
 
             text = imagepage.get()
@@ -363,8 +362,7 @@ class imageFetcher(threading.Thread):
                     foundMatch = True
             if not foundMatch:
                 pywikibot.output(
-                    u'Skipping %s : No suitable license template was found.'
-                    % page.title())
+                    u'Skipping {0!s} : No suitable license template was found.'.format(page.title()))
                 return False
             self.prefetchQueue.put(self.getNewFields(imagepage))
 
@@ -377,7 +375,7 @@ class imageFetcher(threading.Thread):
         for template in imagepage.templates():
             if template in skipTemplates[imagepage.site.language()]:
                 pywikibot.output(
-                    u'Found %s which is on the template skip list' % template)
+                    u'Found {0!s} which is on the template skip list'.format(template))
                 return True
         return False
 
@@ -646,8 +644,7 @@ class userInteraction(threading.Thread):
                 fields = TkdialogICS(fields).getnewmetadata()
 
                 if fields.get('skip'):
-                    pywikibot.output(u'Skipping %s : User pressed skip.'
-                                     % fields.get('imagepage').title())
+                    pywikibot.output(u'Skipping {0!s} : User pressed skip.'.format(fields.get('imagepage').title()))
                     return False
 
                 # Check if the image already exists
@@ -905,22 +902,22 @@ class uploader(threading.Thread):
                     )
         cid += u'== {{int:filedesc}} ==\n'
         cid += u'{{Information\n'
-        cid += u'|description=%(description)s\n' % fields
-        cid += u'|date=%(date)s\n' % fields
-        cid += u'|source=%(source)s\n' % fields
-        cid += u'|author=%(author)s\n' % fields
-        cid += u'|permission=%(permission)s\n' % fields
-        cid += u'|other_versions=%(other_versions)s\n' % fields
+        cid += u'|description={description!s}\n'.format(**fields)
+        cid += u'|date={date!s}\n'.format(**fields)
+        cid += u'|source={source!s}\n'.format(**fields)
+        cid += u'|author={author!s}\n'.format(**fields)
+        cid += u'|permission={permission!s}\n'.format(**fields)
+        cid += u'|other_versions={other_versions!s}\n'.format(**fields)
         cid += u'}}\n'
         cid += u'== {{int:license}} ==\n'
-        cid += u'%(licensetemplate)s\n' % fields
+        cid += u'{licensetemplate!s}\n'.format(**fields)
         cid += u'\n'
         cid += self.getOriginalUploadLog(fields.get('imagepage'))
         cid += u'__NOTOC__\n'
         if fields.get('categories').strip() == u'':
             cid = cid + u'{{Subst:Unc}}'
         else:
-            cid = cid + u'%(categories)s\n' % fields
+            cid = cid + u'{categories!s}\n'.format(**fields)
         return cid
 
     def getOriginalUploadLog(self, imagepage):

--- a/scripts/imageharvest.py
+++ b/scripts/imageharvest.py
@@ -106,7 +106,7 @@ def main(give_url, image_url, desc):
         ilinks = get_imagelinks(url)
 
     for image in ilinks:
-        if pywikibot.input_yn(u'Include image %s?' % image, default=False, automatic_quit=False):
+        if pywikibot.input_yn(u'Include image {0!s}?'.format(image), default=False, automatic_quit=False):
             desc = pywikibot.input(u"Give the description of this image:")
             categories = []
             while True:
@@ -115,10 +115,9 @@ def main(give_url, image_url, desc):
                 if not cat.strip():
                     break
                 if ":" in cat:
-                    categories.append(u"[[%s]]" % cat)
+                    categories.append(u"[[{0!s}]]".format(cat))
                 else:
-                    categories.append(u"[[%s:%s]]"
-                                      % (mysite.namespace(14), cat))
+                    categories.append(u"[[{0!s}:{1!s}]]".format(mysite.namespace(14), cat))
             desc += "\r\n\r\n" + basicdesc + "\r\n\r\n" + \
                     "\r\n".join(categories)
             uploadBot = upload.UploadRobot(image, description=desc)

--- a/scripts/imagerecat.py
+++ b/scripts/imagerecat.py
@@ -166,7 +166,7 @@ def getCommonshelperCats(imagepage):
             if tries < maxtries:
                 tries += 1
                 commonsHelperPage = fetch(
-                    "https://toolserver.org/~daniel/WikiSense/CommonSense.php?%s" % parameters)
+                    "https://toolserver.org/~daniel/WikiSense/CommonSense.php?{0!s}".format(parameters))
                 matches = commonsenseRe.search(
                     commonsHelperPage.content)
                 gotInfo = True
@@ -204,7 +204,7 @@ def getOpenStreetMapCats(latitude, longitude):
     result = []
     locationList = getOpenStreetMap(latitude, longitude)
     for i in range(0, len(locationList)):
-        pywikibot.log(u'Working on %r' % locationList[i])
+        pywikibot.log(u'Working on {0!r}'.format(locationList[i]))
         if i <= len(locationList) - 3:
             category = getCategoryByName(name=locationList[i],
                                          parent=locationList[i + 1],
@@ -230,7 +230,7 @@ def getOpenStreetMap(latitude, longitude):
     parameters = urlencode({'lat': latitude, 'lon': longitude, 'accept-language': 'en'})
     while not gotInfo:
         try:
-            page = fetch('https://nominatim.openstreetmap.org/reverse?format=xml&%s' % parameters)
+            page = fetch('https://nominatim.openstreetmap.org/reverse?format=xml&{0!s}'.format(parameters))
             et = xml.etree.ElementTree.fromstring(page.content)
             gotInfo = True
         except IOError:
@@ -247,10 +247,9 @@ def getOpenStreetMap(latitude, longitude):
         if addresspart.tag in validParts:
             result.append(addresspart.text)
         elif addresspart.tag in invalidParts:
-            pywikibot.output(u'Dropping %s, %s' % (addresspart.tag, addresspart.text))
+            pywikibot.output(u'Dropping {0!s}, {1!s}'.format(addresspart.tag, addresspart.text))
         else:
-            pywikibot.warning('%s, %s is not in addressparts lists'
-                              % (addresspart.tag, addresspart.text))
+            pywikibot.warning('{0!s}, {1!s} is not in addressparts lists'.format(addresspart.tag, addresspart.text))
     return result
 
 
@@ -385,7 +384,7 @@ def filterParents(categories):
     filterCategoriesRe = re.compile(r'\[\[Category:([^\]]*)\]\]')
     try:
         filterCategoriesPage = fetch(
-            "https://toolserver.org/~multichill/filtercats.php?%s" % parameters)
+            "https://toolserver.org/~multichill/filtercats.php?{0!s}".format(parameters))
         result = filterCategoriesRe.findall(
             filterCategoriesPage.content)
     except IOError:
@@ -436,16 +435,16 @@ def getCheckCategoriesTemplate(usage, galleries, ncats):
               'CURRENTMONTHNAME}}|day={{subst:CURRENTDAY}}\n')
     usageCounter = 1
     for (lang, project, article) in usage:
-        result += u'|lang%d=%s' % (usageCounter, lang)
-        result += u'|wiki%d=%s' % (usageCounter, project)
-        result += u'|article%d=%s' % (usageCounter, article)
+        result += u'|lang{0:d}={1!s}'.format(usageCounter, lang)
+        result += u'|wiki{0:d}={1!s}'.format(usageCounter, project)
+        result += u'|article{0:d}={1!s}'.format(usageCounter, article)
         result += u'\n'
         usageCounter += 1
     galleryCounter = 1
     for gallery in galleries:
-        result += u'|gallery%d=%s' % (galleryCounter, gallery.replace('_', ' ')) + u'\n'
+        result += u'|gallery{0:d}={1!s}'.format(galleryCounter, gallery.replace('_', ' ')) + u'\n'
         galleryCounter += 1
-    result += u'|ncats=%d\n' % ncats
+    result += u'|ncats={0:d}\n'.format(ncats)
     result += u'}}\n'
     return result
 

--- a/scripts/imagetransfer.py
+++ b/scripts/imagetransfer.py
@@ -136,7 +136,7 @@ class ImageTransferBot(object):
         """
         sourceSite = sourceImagePage.site
         url = sourceImagePage.fileUrl().encode('utf-8')
-        pywikibot.output(u"URL should be: %s" % url)
+        pywikibot.output(u"URL should be: {0!s}".format(url))
         # localize the text that should be printed on the image description page
         try:
             description = sourceImagePage.get()
@@ -146,8 +146,8 @@ class ImageTransferBot(object):
                 for old, new in licenseTemplates[
                         (sourceSite.sitename,
                          self.targetSite.sitename)].items():
-                    new = '{{%s}}' % new
-                    old = re.compile('{{%s}}' % old)
+                    new = '{{{{{0!s}}}}}'.format(new)
+                    old = re.compile('{{{{{0!s}}}}}'.format(old))
                     description = textlib.replaceExcept(description, old, new,
                                                         ['comment', 'math',
                                                          'nowiki', 'pre'])
@@ -190,8 +190,7 @@ class ImageTransferBot(object):
                    sourceSite.family.name in config.usernames and \
                    sourceSite.lang in config.usernames[sourceSite.family.name]:
                     # add the nowCommons template.
-                    pywikibot.output(u'Adding nowCommons template to %s'
-                                     % sourceImagePage.title())
+                    pywikibot.output(u'Adding nowCommons template to {0!s}'.format(sourceImagePage.title()))
                     sourceImagePage.put(sourceImagePage.get() + '\n\n' +
                                         nowCommonsTemplate[sourceSite.lang]
                                         % targetFilename,
@@ -202,8 +201,7 @@ class ImageTransferBot(object):
         for i in range(len(imagelist)):
             image = imagelist[i]
             print("-" * 60)
-            pywikibot.output(u"%s. Found image: %s"
-                             % (i, image.title(asLink=True)))
+            pywikibot.output(u"{0!s}. Found image: {1!s}".format(i, image.title(asLink=True)))
             try:
                 # Show the image description page's contents
                 pywikibot.output(image.get())
@@ -213,12 +211,11 @@ class ImageTransferBot(object):
                 # to upload anyway, using another name.
                 try:
                     # Maybe the image is on the target site already
-                    targetTitle = '%s:%s' % (self.targetSite.namespaces.FILE,
+                    targetTitle = '{0!s}:{1!s}'.format(self.targetSite.namespaces.FILE,
                                              image.title().split(':', 1)[1])
                     targetImage = pywikibot.Page(self.targetSite, targetTitle)
                     targetImage.get()
-                    pywikibot.output(u"Image with this name is already on %s."
-                                     % self.targetSite)
+                    pywikibot.output(u"Image with this name is already on {0!s}.".format(self.targetSite))
                     print("-" * 60)
                     pywikibot.output(targetImage.get())
                     sys.exit()

--- a/scripts/interwiki.py
+++ b/scripts/interwiki.py
@@ -982,8 +982,7 @@ class Subject(interwiki_graph.Subject):
         # Bug-check: Isn't there any work still in progress? We can't work on
         # different sites at a time!
         if len(self.pending) > 0:
-            raise "BUG: Can't start to work on %s; still working on %s" \
-                  % (site, self.pending)
+            raise "BUG: Can't start to work on {0!s}; still working on {1!s}".format(site, self.pending)
         # Prepare a list of suitable pages
         result = []
         for page in self.todo.filter(site):
@@ -1019,8 +1018,7 @@ class Subject(interwiki_graph.Subject):
         if globalvar.nobackonly and self.originPage:
             if page == self.originPage:
                 try:
-                    pywikibot.output(u"%s has a backlink from %s."
-                                     % (page, linkingPage))
+                    pywikibot.output(u"{0!s} has a backlink from {1!s}.".format(page, linkingPage))
                 except UnicodeDecodeError:
                     pywikibot.output(u"Found a backlink for a page.")
                 self.makeForcedStop(counter)
@@ -1112,8 +1110,7 @@ class Subject(interwiki_graph.Subject):
                                                   None)
                         else:
                             pywikibot.output(
-                                u"NOTE: ignoring %s and its interwiki links"
-                                % linkedPage)
+                                u"NOTE: ignoring {0!s} and its interwiki links".format(linkedPage))
                         return True
         else:
             # same namespaces, no problem
@@ -1124,8 +1121,7 @@ class Subject(interwiki_graph.Subject):
         """Check for ignoring pages."""
         if self.originPage and globalvar.same == 'wiktionary':
             if page.title().lower() != self.originPage.title().lower():
-                pywikibot.output(u"NOTE: Ignoring %s for %s in wiktionary mode"
-                                 % (page, self.originPage))
+                pywikibot.output(u"NOTE: Ignoring {0!s} for {1!s} in wiktionary mode".format(page, self.originPage))
                 return True
             elif (page.title() != self.originPage.title() and
                   self.originPage.site.nocapitalize and
@@ -1215,23 +1211,22 @@ class Subject(interwiki_graph.Subject):
     def isIgnored(self, page):
         """Return True if pages is to be ignored."""
         if page.site.lang in globalvar.neverlink:
-            pywikibot.output(u"Skipping link %s to an ignored language" % page)
+            pywikibot.output(u"Skipping link {0!s} to an ignored language".format(page))
             return True
         if page in globalvar.ignore:
-            pywikibot.output(u"Skipping link %s to an ignored page" % page)
+            pywikibot.output(u"Skipping link {0!s} to an ignored page".format(page))
             return True
         return False
 
     def reportInterwikilessPage(self, page):
         """Report interwikiless page."""
         if not globalvar.quiet:
-            pywikibot.output(u"NOTE: %s does not have any interwiki links"
-                             % self.originPage)
+            pywikibot.output(u"NOTE: {0!s} does not have any interwiki links".format(self.originPage))
         if config.without_interwiki:
             f = codecs.open(
                 pywikibot.config.datafilepath('without_interwiki.txt'),
                 'a', 'utf-8')
-            f.write(u"# %s \n" % page)
+            f.write(u"# {0!s} \n".format(page))
             f.close()
 
     def askForHints(self, counter):
@@ -1318,8 +1313,7 @@ class Subject(interwiki_graph.Subject):
             if not page.exists():
                 globalvar.remove.append(unicode(page))
                 if not globalvar.quiet:
-                    pywikibot.output(u"NOTE: %s does not exist. Skipping."
-                                     % page)
+                    pywikibot.output(u"NOTE: {0!s} does not exist. Skipping.".format(page))
                 if page == self.originPage:
                     # The page we are working on is the page that does not
                     # exist. No use in doing any work on it in that case.
@@ -1341,8 +1335,7 @@ class Subject(interwiki_graph.Subject):
                 else:
                     redirectTargetPage = page.getCategoryRedirectTarget()
                 if not globalvar.quiet:
-                    pywikibot.output(u"NOTE: %s is %sredirect to %s"
-                                     % (page, redir, redirectTargetPage))
+                    pywikibot.output(u"NOTE: {0!s} is {1!s}redirect to {2!s}".format(page, redir, redirectTargetPage))
                 if self.originPage is None or page == self.originPage:
                     # the 1st existig page becomes the origin page, if none was
                     # supplied
@@ -1364,18 +1357,16 @@ class Subject(interwiki_graph.Subject):
                         self.todo = PageTree()
                 elif not globalvar.followredirect:
                     if not globalvar.quiet:
-                        pywikibot.output(u"NOTE: not following %sredirects."
-                                         % redir)
+                        pywikibot.output(u"NOTE: not following {0!s}redirects.".format(redir))
                 elif page.isStaticRedirect():
                     if not globalvar.quiet:
                         pywikibot.output(
-                            u"NOTE: not following static %sredirects." % redir)
+                            u"NOTE: not following static {0!s}redirects.".format(redir))
                 elif (page.site.family == redirectTargetPage.site.family and
                       not self.skipPage(page, redirectTargetPage, counter)):
                     if self.addIfNew(redirectTargetPage, counter, page):
                         if config.interwiki_shownew:
-                            pywikibot.output(u"%s: %s gives new %sredirect %s"
-                                             % (self.originPage, page, redir,
+                            pywikibot.output(u"{0!s}: {1!s} gives new {2!s}redirect {3!s}".format(self.originPage, page, redir,
                                                 redirectTargetPage))
                 continue
 
@@ -1384,7 +1375,7 @@ class Subject(interwiki_graph.Subject):
             elif page_empty_check(page):
                 globalvar.remove.append(unicode(page))
                 if not globalvar.quiet:
-                    pywikibot.output(u"NOTE: %s is empty. Skipping." % page)
+                    pywikibot.output(u"NOTE: {0!s} is empty. Skipping.".format(page))
                 if page == self.originPage:
                     for site, count in self.todo.siteCounts():
                         counter.minus(site, count)
@@ -1395,8 +1386,7 @@ class Subject(interwiki_graph.Subject):
 
             elif page.section():
                 if not globalvar.quiet:
-                    pywikibot.output(u"NOTE: %s is a page section. Skipping."
-                                     % page)
+                    pywikibot.output(u"NOTE: {0!s} is a page section. Skipping.".format(page))
                 continue
 
             # Page exists, isnt a redirect, and is a plain link (no section)
@@ -1408,14 +1398,12 @@ class Subject(interwiki_graph.Subject):
                 iw = page.langlinks()
             except pywikibot.UnknownSite:
                 if not globalvar.quiet:
-                    pywikibot.output(u"NOTE: site %s does not exist."
-                                     % page.site)
+                    pywikibot.output(u"NOTE: site {0!s} does not exist.".format(page.site))
                 continue
 
             (skip, alternativePage) = self.disambigMismatch(page, counter)
             if skip:
-                pywikibot.output(u"NOTE: ignoring %s and its interwiki links"
-                                 % page)
+                pywikibot.output(u"NOTE: ignoring {0!s} and its interwiki links".format(page))
                 self.done.remove(page)
                 iw = ()
                 if alternativePage:
@@ -1452,15 +1440,13 @@ class Subject(interwiki_graph.Subject):
                     f = codecs.open(
                         pywikibot.config.datafilepath('autonomous_problems.dat'),
                         'a', 'utf-8')
-                    f.write(u"* %s {Found more than one link for %s}"
-                            % (self.originPage, page.site))
+                    f.write(u"* {0!s} {{Found more than one link for {1!s}}}".format(self.originPage, page.site))
                     if config.interwiki_graph and config.interwiki_graph_url:
                         filename = interwiki_graph.getFilename(
                             self.originPage,
                             extension=config.interwiki_graph_formats[0])
                         f.write(
-                            ' [%s%s graph]'
-                            % (config.interwiki_graph_url, filename))
+                            ' [{0!s}{1!s} graph]'.format(config.interwiki_graph_url, filename))
                     f.write("\n")
                     f.close()
                 # FIXME: What errors are we catching here?
@@ -1478,8 +1464,7 @@ class Subject(interwiki_graph.Subject):
                 if globalvar.hintsareright:
                     if linkedPage.site in self.hintedsites:
                         pywikibot.output(
-                            'NOTE: %s: %s extra interwiki on hinted site ignored %s'
-                            % (self.originPage, page, linkedPage))
+                            'NOTE: {0!s}: {1!s} extra interwiki on hinted site ignored {2!s}'.format(self.originPage, page, linkedPage))
                         break
                 if not self.skipPage(page, linkedPage, counter):
                     if globalvar.followinterwiki or page == self.originPage:
@@ -1492,13 +1477,11 @@ class Subject(interwiki_graph.Subject):
                                     # Still, this could be "no problem" as either may be a
                                     # redirect to the other. No way to find out quickly!
                                     pywikibot.output(
-                                        'NOTE: %s: %s gives duplicate interwiki on same site %s'
-                                        % (self.originPage, page, linkedPage))
+                                        'NOTE: {0!s}: {1!s} gives duplicate interwiki on same site {2!s}'.format(self.originPage, page, linkedPage))
                                     break
                             else:
                                 if config.interwiki_shownew:
-                                    pywikibot.output(u"%s: %s gives new interwiki %s"
-                                                     % (self.originPage,
+                                    pywikibot.output(u"{0!s}: {1!s} gives new interwiki {2!s}".format(self.originPage,
                                                         page, linkedPage))
                 if self.forcedStop:
                     break
@@ -1515,7 +1498,7 @@ class Subject(interwiki_graph.Subject):
 
     def problem(self, txt, createneed=True):
         """Report a problem with the resolution of this subject."""
-        pywikibot.output(u"ERROR: %s" % txt)
+        pywikibot.output(u"ERROR: {0!s}".format(txt))
         self.confirm = True
         if createneed:
             self.problemfound = True
@@ -1543,7 +1526,7 @@ class Subject(interwiki_graph.Subject):
                     continue  # inhibit the forwarding families pages to be updated.
                 if site == self.originPage.site:
                     if page != self.originPage:
-                        self.problem(u"Found link to %s" % page)
+                        self.problem(u"Found link to {0!s}".format(page))
                         self.whereReport(page)
                         errorCount += 1
                 else:
@@ -1556,7 +1539,7 @@ class Subject(interwiki_graph.Subject):
         for site, pages in new.items():
             if len(pages) > 1:
                 errorCount += 1
-                self.problem(u"Found more than one link for %s" % site)
+                self.problem(u"Found more than one link for {0!s}".format(site))
 
         if not errorCount and not globalvar.select:
             # no errors, so all lists have only one item
@@ -1578,12 +1561,11 @@ class Subject(interwiki_graph.Subject):
         for site, pages in new.items():
             if len(pages) > 1:
                 pywikibot.output(u"=" * 30)
-                pywikibot.output(u"Links to %s" % site)
+                pywikibot.output(u"Links to {0!s}".format(site))
                 i = 0
                 for page2 in pages:
                     i += 1
-                    pywikibot.output(u"  (%d) Found link to %s in:"
-                                     % (i, page2))
+                    pywikibot.output(u"  ({0:d}) Found link to {1!s} in:".format(i, page2))
                     self.whereReport(page2, indent=8)
 
                 # TODO: allow answer to repeat previous or go back after a mistake
@@ -1605,7 +1587,7 @@ class Subject(interwiki_graph.Subject):
                 if not acceptall:
                     pywikibot.output(u"=" * 30)
                     page2 = pages[0]
-                    pywikibot.output(u"Found link to %s in:" % page2)
+                    pywikibot.output(u"Found link to {0!s} in:".format(page2))
                     self.whereReport(page2, indent=4)
                 while True:
                     if acceptall:
@@ -1651,8 +1633,7 @@ class Subject(interwiki_graph.Subject):
         if not self.untranslated and globalvar.untranslatedonly:
             return
         if self.forcedStop:  # autonomous with problem
-            pywikibot.output(u"======Aborted processing %s======"
-                             % self.originPage)
+            pywikibot.output(u"======Aborted processing {0!s}======".format(self.originPage))
             return
         # The following check is not always correct and thus disabled.
         # self.done might contain no interwiki links because of the -neverlink
@@ -1660,12 +1641,11 @@ class Subject(interwiki_graph.Subject):
 #         if len(self.done) == 1:
 #             # No interwiki at all
 #             return
-        pywikibot.output(u"======Post-processing %s======" % self.originPage)
+        pywikibot.output(u"======Post-processing {0!s}======".format(self.originPage))
         # Assemble list of accepted interwiki links
         new = self.assemble()
         if new is None:  # User said give up
-            pywikibot.output(u"======Aborted processing %s======"
-                             % self.originPage)
+            pywikibot.output(u"======Aborted processing {0!s}======".format(self.originPage))
             return
 
         # Make sure new contains every page link, including the page we are processing
@@ -1713,8 +1693,7 @@ class Subject(interwiki_graph.Subject):
                             page = pywikibot.Page(link)
                             old[page.site] = page
                     except pywikibot.NoPage:
-                        pywikibot.output(u"BUG>>> %s no longer exists?"
-                                         % new[site])
+                        pywikibot.output(u"BUG>>> {0!s} no longer exists?".format(new[site]))
                         continue
                     mods, mcomment, adding, removing, modifying \
                         = compareLanguages(old, new, insite=lclSite)
@@ -1786,16 +1765,15 @@ class Subject(interwiki_graph.Subject):
                 raise SaveError(u'-localonly and page != originPage')
         if page.section():
             # This is not a page, but a subpage. Do not edit it.
-            pywikibot.output(u"Not editing %s: not doing interwiki on subpages"
-                             % page)
+            pywikibot.output(u"Not editing {0!s}: not doing interwiki on subpages".format(page))
             raise SaveError(u'Link has a #section')
         try:
             pagetext = page.get()
         except pywikibot.NoPage:
-            pywikibot.output(u"Not editing %s: page does not exist" % page)
+            pywikibot.output(u"Not editing {0!s}: page does not exist".format(page))
             raise SaveError(u'Page doesn\'t exist')
         if page_empty_check(page):
-            pywikibot.output(u"Not editing %s: page is empty" % page)
+            pywikibot.output(u"Not editing {0!s}: page is empty".format(page))
             raise SaveError(u'Page is empty.')
 
         # clone original newPages dictionary, so that we can modify it to the
@@ -1811,9 +1789,8 @@ class Subject(interwiki_graph.Subject):
                    (ignorepage.site != page.site):
                     if (ignorepage not in interwikis):
                         pywikibot.output(
-                            u"Ignoring link to %(to)s for %(from)s"
-                            % {'to': ignorepage,
-                               'from': page})
+                            u"Ignoring link to {to!s} for {from!s}".format(**{'to': ignorepage,
+                               'from': page}))
                         new.pop(ignorepage.site)
                     else:
                         pywikibot.output(
@@ -1836,8 +1813,7 @@ class Subject(interwiki_graph.Subject):
             if pltmp is not None:
                 s = pltmp
             pywikibot.output(
-                u"BUG>>> %s is not in the list of new links! Found %s."
-                % (page, s))
+                u"BUG>>> {0!s} is not in the list of new links! Found {1!s}.".format(page, s))
             raise SaveError(u'BUG: sanity check failed')
 
         # Avoid adding an iw link back to itself
@@ -1883,13 +1859,13 @@ class Subject(interwiki_graph.Subject):
                                                                            insite=page.site)
         if not mods:
             if not globalvar.quiet:
-                pywikibot.output(u'No changes needed on page %s' % page)
+                pywikibot.output(u'No changes needed on page {0!s}'.format(page))
             return False
 
         # Show a message in purple.
         pywikibot.output(color_format(
             '{lightpurple}Updating links on page {0}.{default}', page))
-        pywikibot.output(u"Changes to be made: %s" % mods)
+        pywikibot.output(u"Changes to be made: {0!s}".format(mods))
         oldtext = page.get()
         template = (page.namespace() == 10)
         newtext = textlib.replaceLanguageLinks(oldtext, new,
@@ -1900,12 +1876,10 @@ class Subject(interwiki_graph.Subject):
         if not botMayEdit(page):
             if template:
                 pywikibot.output(
-                    u'SKIPPING: %s should have interwiki links on subpage.'
-                    % page)
+                    u'SKIPPING: {0!s} should have interwiki links on subpage.'.format(page))
             else:
                 pywikibot.output(
-                    u'SKIPPING: %s is under construction or to be deleted.'
-                    % page)
+                    u'SKIPPING: {0!s} is under construction or to be deleted.'.format(page))
             return False
         if newtext == oldtext:
             return False
@@ -1917,8 +1891,7 @@ class Subject(interwiki_graph.Subject):
 
         # Allow for special case of a self-pointing interwiki link
         if removing and removing != [page.site]:
-            self.problem(u'Found incorrect link to %s in %s'
-                         % (", ".join([x.code for x in removing]), page),
+            self.problem(u'Found incorrect link to {0!s} in {1!s}'.format(", ".join([x.code for x in removing]), page),
                          createneed=False)
             ask = True
         if globalvar.force or globalvar.cleanup:
@@ -1959,7 +1932,7 @@ class Subject(interwiki_graph.Subject):
                     else:
                         page.put(newtext, summary=mcomment)
                 except pywikibot.LockedPage:
-                    pywikibot.output(u'Page %s is locked. Skipping.' % page)
+                    pywikibot.output(u'Page {0!s} is locked. Skipping.'.format(page))
                     raise SaveError(u'Locked')
                 except pywikibot.EditConflict:
                     pywikibot.output(
@@ -1967,26 +1940,23 @@ class Subject(interwiki_graph.Subject):
                     raise SaveError(u'Edit conflict')
                 except (pywikibot.SpamfilterError) as error:
                     pywikibot.output(
-                        u'ERROR putting page: %s blacklisted by spamfilter. Giving up.'
-                        % (error.url,))
+                        u'ERROR putting page: {0!s} blacklisted by spamfilter. Giving up.'.format(error.url))
                     raise SaveError(u'Spam filter')
                 except (pywikibot.PageNotSaved) as error:
-                    pywikibot.output(u'ERROR putting page: %s' % (error.args,))
+                    pywikibot.output(u'ERROR putting page: {0!s}'.format(error.args))
                     raise SaveError(u'PageNotSaved')
                 except (socket.error, IOError) as error:
                     if timeout > 3600:
                         raise
-                    pywikibot.output(u'ERROR putting page: %s' % (error.args,))
-                    pywikibot.output(u'Sleeping %i seconds before trying again.'
-                                     % (timeout,))
+                    pywikibot.output(u'ERROR putting page: {0!s}'.format(error.args))
+                    pywikibot.output(u'Sleeping {0:d} seconds before trying again.'.format(timeout))
                     timeout *= 2
                     time.sleep(timeout)
                 except pywikibot.ServerError:
                     if timeout > 3600:
                         raise
                     pywikibot.output(u'ERROR putting page: ServerError.')
-                    pywikibot.output(u'Sleeping %i seconds before trying again.'
-                                     % (timeout,))
+                    pywikibot.output(u'Sleeping {0:d} seconds before trying again.'.format(timeout))
                     timeout *= 2
                     time.sleep(timeout)
                 else:
@@ -1995,8 +1965,7 @@ class Subject(interwiki_graph.Subject):
         elif answer == 'g':
             raise GiveUpOnPage(u'User asked us to give up')
         else:
-            raise LinkMustBeRemoved(u'Found incorrect link to %s in %s'
-                                    % (", ".join([x.code for x in removing]),
+            raise LinkMustBeRemoved(u'Found incorrect link to {0!s} in {1!s}'.format(", ".join([x.code for x in removing]),
                                        page))
 
     def reportBacklinks(self, new, updatedSites):
@@ -2018,7 +1987,7 @@ class Subject(interwiki_graph.Subject):
                         linkedPages = set(pywikibot.Page(l) for l in page.iterlanglinks())
                     except pywikibot.NoPage:
                         pywikibot.output(
-                            u"WARNING: Page %s does no longer exist?!" % page)
+                            u"WARNING: Page {0!s} does no longer exist?!".format(page))
                         break
                     # To speed things up, create a dictionary which maps sites
                     # to pages. This assumes that there is only one interwiki
@@ -2031,14 +2000,12 @@ class Subject(interwiki_graph.Subject):
                             try:
                                 linkedPage = linkedPagesDict[expectedPage.site]
                                 pywikibot.output(
-                                    u"WARNING: %s: %s does not link to %s but to %s"
-                                    % (page.site.family.name,
+                                    u"WARNING: {0!s}: {1!s} does not link to {2!s} but to {3!s}".format(page.site.family.name,
                                        page, expectedPage, linkedPage))
                             except KeyError:
                                 if not expectedPage.site.is_data_repository():
                                     pywikibot.output(
-                                        u"WARNING: %s: %s does not link to %s"
-                                        % (page.site.family.name,
+                                        u"WARNING: {0!s}: {1!s} does not link to {2!s}".format(page.site.family.name,
                                            page, expectedPage))
                     # Check for superfluous links
                     for linkedPage in linkedPages:
@@ -2047,8 +2014,7 @@ class Subject(interwiki_graph.Subject):
                             # In this case, it was already reported above.
                             if linkedPage.site not in expectedSites:
                                 pywikibot.output(
-                                    u"WARNING: %s: %s links to incorrect %s"
-                                    % (page.site.family.name,
+                                    u"WARNING: {0!s}: {1!s} links to incorrect {2!s}".format(page.site.family.name,
                                        page, linkedPage))
         except (socket.error, IOError):
             pywikibot.output(u'ERROR: could not report backlinks')
@@ -2099,7 +2065,7 @@ class InterwikiBot(object):
         dumpfn = pywikibot.config.datafilepath(
             'data',
             'interwiki-dumps',
-            '%s-%s.pickle' % (site.family.name, site.code)
+            '{0!s}-{1!s}.pickle'.format(site.family.name, site.code)
         )
         if append:
             mode = 'appended'
@@ -2108,7 +2074,7 @@ class InterwikiBot(object):
         titles = [s.originPage.title() for s in self.subjects]
         with open(dumpfn, mode[0] + 'b') as f:
             pickle.dump(titles, f, protocol=config.pickle_protocol)
-        pywikibot.output(u'Dump %s (%s) %s.' % (site.code, site.family.name, mode))
+        pywikibot.output(u'Dump {0!s} ({1!s}) {2!s}.'.format(site.code, site.family.name, mode))
         return dumpfn
 
     def generateMore(self, number):
@@ -2120,10 +2086,8 @@ class InterwikiBot(object):
         """
         fs = self.firstSubject()
         if fs and (not globalvar.quiet):
-            pywikibot.output(u"NOTE: The first unfinished subject is %s"
-                             % fs.originPage)
-        pywikibot.output(u"NOTE: Number of pages queued is %d, trying to add %d more."
-                         % (len(self.subjects), number))
+            pywikibot.output(u"NOTE: The first unfinished subject is {0!s}".format(fs.originPage))
+        pywikibot.output(u"NOTE: Number of pages queued is {0:d}, trying to add {1:d} more.".format(len(self.subjects), number))
         for i in range(number):
             try:
                 while True:
@@ -2133,20 +2097,19 @@ class InterwikiBot(object):
                         pywikibot.output(u'IOError occurred; skipping')
                         continue
                     if page in globalvar.skip:
-                        pywikibot.output(u'Skipping: %s is in the skip list' % page)
+                        pywikibot.output(u'Skipping: {0!s} is in the skip list'.format(page))
                         continue
                     if globalvar.skipauto:
                         dictName, year = page.autoFormat()
                         if dictName is not None:
-                            pywikibot.output('Skipping: %s is an auto entry %s(%s)'
-                                             % (page, dictName, year))
+                            pywikibot.output('Skipping: {0!s} is an auto entry {1!s}({2!s})'.format(page, dictName, year))
                             continue
                     if globalvar.parenthesesonly:
                         # Only yield pages that have ( ) in titles
                         if "(" not in page.title():
                             continue
                     if page.isTalkPage():
-                        pywikibot.output(u'Skipping: %s is a talk page' % page)
+                        pywikibot.output(u'Skipping: {0!s} is a talk page'.format(page))
                         continue
                     if page.namespace() == 10:
                         loc = None
@@ -2157,8 +2120,7 @@ class InterwikiBot(object):
                             pass
                         if loc is not None and loc in page.title():
                             pywikibot.output(
-                                'Skipping: %s is a templates subpage'
-                                % page.title())
+                                'Skipping: {0!s} is a templates subpage'.format(page.title()))
                             continue
                     break
 
@@ -2404,7 +2366,7 @@ def readWarnfile(filename, bot):
         # expects a list of strings, so we convert it back.
         # TODO: This is a quite ugly hack, in the future we should maybe make
         # titletranslate expect a list of pagelinks.
-        hintStrings = ['%s:%s' % (hintedPage.site.lang,
+        hintStrings = ['{0!s}:{1!s}'.format(hintedPage.site.lang,
                                   hintedPage.title()) for hintedPage in pagelist]
         bot.add(page, hints=hintStrings)
 
@@ -2535,7 +2497,7 @@ def main(*args):
                 if isinstance(ns, unicode) or isinstance(ns, str):
                     index = site.namespaces.lookup_name(ns)
                     if index is None:
-                        raise ValueError(u'Unknown namespace: %s' % ns)
+                        raise ValueError(u'Unknown namespace: {0!s}'.format(ns))
                     ns = index.id
             namespaces = []
         else:
@@ -2547,7 +2509,7 @@ def main(*args):
         dumpFileName = pywikibot.config.datafilepath(
             'data',
             'interwiki-dumps',
-            u'%s-%s.pickle' % (site.family.name, site.code)
+            u'{0!s}-{1!s}.pickle'.format(site.family.name, site.code)
         )
         try:
             with open(dumpFileName, 'rb') as f:
@@ -2613,7 +2575,7 @@ def main(*args):
         for dumpFileName in restoredFiles:
             try:
                 os.remove(dumpFileName)
-                pywikibot.output(u'Dumpfile %s deleted' % dumpFileName.split('\\')[-1])
+                pywikibot.output(u'Dumpfile {0!s} deleted'.format(dumpFileName.split('\\')[-1]))
             except OSError:
                 pass
 

--- a/scripts/interwikidata.py
+++ b/scripts/interwikidata.py
@@ -109,8 +109,7 @@ class IWBot(ExistingPageBot, SingleSiteBot):
                   'value': self.current_page.title()}
                  }
                 }
-        summary = (u'Bot: New item with sitelink from %s'
-                   % self.current_page.title(asLink=True, insite=self.repo))
+        summary = (u'Bot: New item with sitelink from {0!s}'.format(self.current_page.title(asLink=True, insite=self.repo)))
 
         item = pywikibot.ItemPage(self.repo)
         item.editEntity(data, new='item', summary=summary)
@@ -135,8 +134,8 @@ class IWBot(ExistingPageBot, SingleSiteBot):
         dbnames = [iw_site.dbName() for iw_site in self.iwlangs]
         if set(dbnames) < set(self.current_item.sitelinks.keys()):
             if not self.handle_complicated():
-                warning('Interwiki conflict in %s, skipping...' %
-                        self.current_page.title(asLink=True))
+                warning('Interwiki conflict in {0!s}, skipping...'.format(
+                        self.current_page.title(asLink=True)))
                 return False
         output('Cleaning up the page')
         new_text = pywikibot.textlib.removeLanguageLinks(
@@ -150,23 +149,23 @@ class IWBot(ExistingPageBot, SingleSiteBot):
             try:
                 wd_data.add(pywikibot.ItemPage.fromPage(iw_page))
             except pywikibot.NoPage:
-                warning('Interwiki %s does not exist, skipping...' %
-                        iw_page.title(asLink=True))
+                warning('Interwiki {0!s} does not exist, skipping...'.format(
+                        iw_page.title(asLink=True)))
                 continue
             except pywikibot.InvalidTitle:
-                warning('Invalid title %s, skipping...' %
-                        iw_page.title(asLink=True))
+                warning('Invalid title {0!s}, skipping...'.format(
+                        iw_page.title(asLink=True)))
                 continue
         if len(wd_data) != 1:
-            warning('Interwiki conflict in %s, skipping...' %
-                    self.current_page.title(asLink=True))
+            warning('Interwiki conflict in {0!s}, skipping...'.format(
+                    self.current_page.title(asLink=True)))
             return False
         item = list(wd_data).pop()
         if self.current_page.site.dbName() in item.sitelinks:
-            warning('Interwiki conflict in %s, skipping...' %
-                    item.title(asLink=True))
+            warning('Interwiki conflict in {0!s}, skipping...'.format(
+                    item.title(asLink=True)))
             return False
-        output('Adding link to %s' % item.title())
+        output('Adding link to {0!s}'.format(item.title()))
         item.setSitelink(self.current_page)
         return item
 

--- a/scripts/isbn.py
+++ b/scripts/isbn.py
@@ -1205,8 +1205,7 @@ class ISBN(object):
                 publisherRanges = ranges[groupNumber]
                 break
         else:
-            raise InvalidIsbnException('ISBN %s: group number unknown.'
-                                       % self.code)
+            raise InvalidIsbnException('ISBN {0!s}: group number unknown.'.format(self.code))
 
         # Determine the publisher
         for (start, end) in publisherRanges:
@@ -1216,8 +1215,7 @@ class ISBN(object):
                 rest = rest[length:]
                 break
         else:
-            raise InvalidIsbnException('ISBN %s: publisher number unknown.'
-                                       % self.code)
+            raise InvalidIsbnException('ISBN {0!s}: publisher number unknown.'.format(self.code))
 
         # The rest is the item number and the 1-digit checksum.
         result += rest[:-1] + '-' + rest[-1]
@@ -1247,17 +1245,15 @@ class ISBN13(ISBN):
                 result.append(int(c))
             elif c != '-':
                 raise InvalidIsbnException(
-                    'The ISBN %s contains invalid characters.' % self.code)
+                    'The ISBN {0!s} contains invalid characters.'.format(self.code))
         return result
 
     def checkValidity(self):
         """Check validity of ISBN."""
         if len(self.digits()) != 13:
-            raise InvalidIsbnException('The ISBN %s is not 13 digits long.'
-                                       % self.code)
+            raise InvalidIsbnException('The ISBN {0!s} is not 13 digits long.'.format(self.code))
         if self.calculateChecksum() != self.digits()[-1]:
-            raise InvalidIsbnException('The ISBN checksum of %s is incorrect.'
-                                       % self.code)
+            raise InvalidIsbnException('The ISBN checksum of {0!s} is incorrect.'.format(self.code))
 
     def calculateChecksum(self):
         """
@@ -1294,7 +1290,7 @@ class ISBN10(ISBN):
                 result.append(c)
             elif c != '-':
                 raise InvalidIsbnException(
-                    'The ISBN %s contains invalid characters.' % self.code)
+                    'The ISBN {0!s} contains invalid characters.'.format(self.code))
         return result
 
     def checkChecksum(self):
@@ -1307,18 +1303,15 @@ class ISBN10(ISBN):
         lastDigit = self.digits()[-1]
         if not ((checksum == 10 and lastDigit in 'Xx') or
                 (lastDigit.isdigit() and checksum == int(lastDigit))):
-            raise InvalidIsbnException('The ISBN checksum of %s is incorrect.'
-                                       % self.code)
+            raise InvalidIsbnException('The ISBN checksum of {0!s} is incorrect.'.format(self.code))
 
     def checkValidity(self):
         """Check validity of ISBN."""
         if len(self.digits()) != 10:
-            raise InvalidIsbnException('The ISBN %s is not 10 digits long.'
-                                       % self.code)
+            raise InvalidIsbnException('The ISBN {0!s} is not 10 digits long.'.format(self.code))
         if 'X' in self.digits()[:-1] or 'x' in self.digits()[:-1]:
             raise InvalidIsbnException(
-                'ISBN %s: X is only allowed at the end of the ISBN.'
-                % self.code)
+                'ISBN {0!s}: X is only allowed at the end of the ISBN.'.format(self.code))
         self.checkChecksum()
 
     def toISBN13(self):
@@ -1351,8 +1344,7 @@ def getIsbn(code):
         try:
             i = ISBN10(code)
         except InvalidIsbnException as e10:
-            raise InvalidIsbnException(u'ISBN-13: %s / ISBN-10: %s'
-                                       % (e13, e10))
+            raise InvalidIsbnException(u'ISBN-13: {0!s} / ISBN-10: {1!s}'.format(e13, e10))
     return i
 
 
@@ -1513,21 +1505,16 @@ class IsbnBot(Bot):
             try:
                 self.userPut(page, page.text, new_text, summary=self.comment)
             except pywikibot.EditConflict:
-                pywikibot.output(u'Skipping %s because of edit conflict'
-                                 % page.title())
+                pywikibot.output(u'Skipping {0!s} because of edit conflict'.format(page.title()))
             except pywikibot.SpamfilterError as e:
                 pywikibot.output(
-                    u'Cannot change %s because of blacklist entry %s'
-                    % (page.title(), e.url))
+                    u'Cannot change {0!s} because of blacklist entry {1!s}'.format(page.title(), e.url))
             except pywikibot.LockedPage:
-                pywikibot.output(u'Skipping %s (locked page)'
-                                 % page.title())
+                pywikibot.output(u'Skipping {0!s} (locked page)'.format(page.title()))
         except pywikibot.NoPage:
-            pywikibot.output(u"Page %s does not exist"
-                             % page.title(asLink=True))
+            pywikibot.output(u"Page {0!s} does not exist".format(page.title(asLink=True)))
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u"Page %s is a redirect; skipping."
-                             % page.title(asLink=True))
+            pywikibot.output(u"Page {0!s} is a redirect; skipping.".format(page.title(asLink=True)))
 
     def run(self):
         """Run the bot."""
@@ -1585,8 +1572,7 @@ class IsbnWikibaseBot(WikidataBot):
                         item.claims[self.isbn_13_prop_id].append(claim)
                     else:
                         item.claims[self.isbn_13_prop_id] = [claim]
-                    change_messages.append('Changing %s (%s) to %s (%s)' %
-                                           (self.isbn_10_prop_id, old_isbn,
+                    change_messages.append('Changing {0!s} ({1!s}) to {2!s} ({3!s})'.format(self.isbn_10_prop_id, old_isbn,
                                             self.isbn_13_prop_id, new_isbn))
                     continue
 
@@ -1596,8 +1582,7 @@ class IsbnWikibaseBot(WikidataBot):
                 assert new_isbn.startswith('ISBN '), 'ISBN should start with "ISBN"'
                 new_isbn = new_isbn[5:]
                 claim.setTarget(new_isbn)
-                change_messages.append('Changing %s (%s --> %s)' %
-                                       (self.isbn_10_prop_id, old_isbn,
+                change_messages.append('Changing {0!s} ({1!s} --> {2!s})'.format(self.isbn_10_prop_id, old_isbn,
                                         new_isbn))
 
         # -format is the only option that has any effect on ISBN13
@@ -1615,7 +1600,7 @@ class IsbnWikibaseBot(WikidataBot):
                 if old_isbn == new_isbn:
                     continue
                 change_messages.append(
-                    'Changing %s (%s --> %s)' % (self.isbn_13_prop_id,
+                    'Changing {0!s} ({1!s} --> {2!s})'.format(self.isbn_13_prop_id,
                                                  claim.getTarget(), new_isbn))
                 claim.setTarget(new_isbn)
 

--- a/scripts/listpages.py
+++ b/scripts/listpages.py
@@ -149,7 +149,7 @@ class Formatter(object):
                 self.trs_title = page._link.ns_title(onsite=self.onsite)
             # Fallback if no corresponding namespace is found in onsite.
             except pywikibot.Error:
-                self.trs_title = u'%s:%s' % (default, page._link.title)
+                self.trs_title = u'{0!s}:{1!s}'.format(default, page._link.title)
 
     def output(self, num=None, fmt=1):
         """Output formatted string."""
@@ -219,7 +219,7 @@ def main(*args):
             base_dir = os.path.normpath(os.path.join(os.getcwd(), base_dir))
 
         if not os.path.exists(base_dir):
-            pywikibot.output(u'Directory "%s" does not exist.' % base_dir)
+            pywikibot.output(u'Directory "{0!s}" does not exist.'.format(base_dir))
             choice = pywikibot.input_yn(
                 u'Do you want to create it ("No" to continue without saving)?')
             if choice:
@@ -260,10 +260,10 @@ def main(*args):
                     pywikibot.output(err)
             if base_dir:
                 filename = os.path.join(base_dir, page.title(as_filename=True))
-                pywikibot.output(u'Saving %s to %s' % (page.title(), filename))
+                pywikibot.output(u'Saving {0!s} to {1!s}'.format(page.title(), filename))
                 with open(filename, mode='wb') as f:
                     f.write(page.text.encode(encoding))
-        pywikibot.output(u"%i page(s) found" % i)
+        pywikibot.output(u"{0:d} page(s) found".format(i))
         if page_target:
             page_target.text = '\n'.join(output_list)
             page_target.save(summary=summary)

--- a/scripts/login.py
+++ b/scripts/login.py
@@ -87,8 +87,8 @@ def _oauth_login(site):
     login_manager.login()
     identity = login_manager.identity
     if identity is None:
-        pywikibot.error('Invalid OAuth info for %(site)s.' %
-                        {'site': site})
+        pywikibot.error('Invalid OAuth info for {site!s}.'.format(**
+                        {'site': site}))
     elif site.username() != identity['username']:
         pywikibot.error('Logged in on %(site)s via OAuth as %(wrong)s, '
                         'but expect as %(right)s'
@@ -104,9 +104,9 @@ def _oauth_login(site):
                             'consumer': consumer_key})
         pywikibot.output('NOTE: To use OAuth, you need to copy the '
                          'following line to your user-config.py:')
-        pywikibot.output('authenticate[\'%(hostname)s\'] = %(oauth_token)s' %
+        pywikibot.output('authenticate[\'{hostname!s}\'] = {oauth_token!s}'.format(**
                          {'hostname': site.hostname(),
-                          'oauth_token': oauth_token})
+                          'oauth_token': oauth_token}))
 
 
 def main(*args):

--- a/scripts/lonelypages.py
+++ b/scripts/lonelypages.py
@@ -129,7 +129,7 @@ class LonelyPagesBot(SingleSiteBot):
             except ValueError as e:
                 orphan_template = e
         if orphan_template is None or isinstance(orphan_template, ValueError):
-            err_message = 'Missing configuration for site %s' % self.site
+            err_message = 'Missing configuration for site {0!s}'.format(self.site)
             suggest_help(exception=orphan_template, additional_text=err_message)
             sys.exit(err_message)
         else:
@@ -140,11 +140,10 @@ class LonelyPagesBot(SingleSiteBot):
             try:
                 self.disambigtext = self.disambigpage.get()
             except pywikibot.NoPage:
-                pywikibot.output(u"%s doesn't esist, skip!" % self.disambigpage.title())
+                pywikibot.output(u"{0!s} doesn't esist, skip!".format(self.disambigpage.title()))
                 self.disambigtext = ''
             except pywikibot.IsRedirectPage:
-                pywikibot.output(u"%s is a redirect, don't use it!"
-                                 % self.disambigpage.title())
+                pywikibot.output(u"{0!s} is a redirect, don't use it!".format(self.disambigpage.title()))
                 self.options['disambigPage'] = None
 
     @property
@@ -160,11 +159,10 @@ class LonelyPagesBot(SingleSiteBot):
                 getenable = enable.get()
             except pywikibot.NoPage:
                 pywikibot.output(
-                    u"%s doesn't esist, I use the page as if it was blank!"
-                    % enable.title())
+                    u"{0!s} doesn't esist, I use the page as if it was blank!".format(enable.title()))
                 getenable = ''
             except pywikibot.IsRedirectPage:
-                pywikibot.output(u"%s is a redirect, skip!" % enable.title())
+                pywikibot.output(u"{0!s} is a redirect, skip!".format(enable.title()))
                 getenable = ''
             return getenable == 'enable'
         return True
@@ -180,46 +178,43 @@ class LonelyPagesBot(SingleSiteBot):
 
     def treat(self, page):
         """Check if page is applicable and not marked and add template then."""
-        pywikibot.output(u"Checking %s..." % page.title())
+        pywikibot.output(u"Checking {0!s}...".format(page.title()))
         if page.isRedirectPage():  # If redirect, skip!
-            pywikibot.output(u'%s is a redirect! Skip...' % page.title())
+            pywikibot.output(u'{0!s} is a redirect! Skip...'.format(page.title()))
             return
         refs = list(page.getReferences(total=1))
         if len(refs) > 0:
-            pywikibot.output(u"%s isn't orphan! Skip..." % page.title())
+            pywikibot.output(u"{0!s} isn't orphan! Skip...".format(page.title()))
             return
         else:
             # no refs, no redirect; check if there's already the template
             try:
                 oldtxt = page.get()
             except pywikibot.NoPage:
-                pywikibot.output(u"%s doesn't exist! Skip..." % page.title())
+                pywikibot.output(u"{0!s} doesn't exist! Skip...".format(page.title()))
                 return
             except pywikibot.IsRedirectPage:
-                pywikibot.output(u"%s is a redirect! Skip..." % page.title())
+                pywikibot.output(u"{0!s} is a redirect! Skip...".format(page.title()))
                 return
             if self.settings.regex.search(oldtxt):
                 pywikibot.output(
-                    u'Your regex has found something in %s, skipping...'
-                    % page.title())
+                    u'Your regex has found something in {0!s}, skipping...'.format(page.title()))
                 return
             if page.isDisambig() and self.getOption('disambigPage') is not None:
-                pywikibot.output(u'%s is a disambig page, report..'
-                                 % page.title())
+                pywikibot.output(u'{0!s} is a disambig page, report..'.format(page.title()))
                 if not page.title().lower() in self.disambigtext.lower():
-                    self.disambigtext = u"%s\n*[[%s]]" % (self.disambigtext, page.title())
+                    self.disambigtext = u"{0!s}\n*[[{1!s}]]".format(self.disambigtext, page.title())
                     self.disambigpage.text = self.disambigtext
                     self.disambigpage.save(self.commentdisambig)
                     return
             # Is the page a disambig but there's not disambigPage? Skip!
             elif page.isDisambig():
-                pywikibot.output(u'%s is a disambig page, skip...'
-                                 % page.title())
+                pywikibot.output(u'{0!s} is a disambig page, skip...'.format(page.title()))
                 return
             else:
                 # Ok, the page need the template. Let's put it there!
                 # Adding the template in the text
-                newtxt = '%s\n%s' % (self.settings.template, oldtxt)
+                newtxt = '{0!s}\n{1!s}'.format(self.settings.template, oldtxt)
                 self.userPut(page, oldtxt, newtxt, summary=self.comment)
 
 

--- a/scripts/maintenance/cache.py
+++ b/scripts/maintenance/cache.py
@@ -129,11 +129,10 @@ class CacheEntry(api.CachedRequest):
         end = self.key.index(')')
 
         if not end:
-            raise ParseError('End of Site() keyword not found: %s' % self.key)
+            raise ParseError('End of Site() keyword not found: {0!s}'.format(self.key))
 
         if 'Site' not in self.key[0:start]:
-            raise ParseError('Site() keyword not found at start of key: %s'
-                             % self.key)
+            raise ParseError('Site() keyword not found at start of key: {0!s}'.format(self.key))
 
         site = self.key[0:end + 1]
         if site[0:5] == 'Site(':
@@ -156,20 +155,17 @@ class CacheEntry(api.CachedRequest):
 
             end = self.key.index(')', start + 5)
             if not end:
-                raise ParseError('End of User() keyword not found: %s'
-                                 % self.key)
+                raise ParseError('End of User() keyword not found: {0!s}'.format(self.key))
             username = self.key[start:end]
         elif self.key[start:start + 12] == 'LoginStatus(':
             end = self.key.index(')', start + 12)
             if not end:
-                raise ParseError('End of LoginStatus() keyword not found: %s'
-                                 % self.key)
+                raise ParseError('End of LoginStatus() keyword not found: {0!s}'.format(self.key))
             login_status = self.key[start:end + 1]
         # If the key does not contain User(..) or LoginStatus(..),
         # it must be the old key format which only contains Site and params
         elif self.key[start:start + 3] != "[('":
-            raise ParseError('Keyword after Site not recognised: %s...'
-                             % self.key)
+            raise ParseError('Keyword after Site not recognised: {0!s}...'.format(self.key))
 
         start = end + 1
 
@@ -188,8 +184,7 @@ class CacheEntry(api.CachedRequest):
             raise ParseError('No Site')
         self.site = eval(site)
         if login_status:
-            self.site._loginstatus = eval('LoginStatus.%s'
-                                          % login_status[12:-1])
+            self.site._loginstatus = eval('LoginStatus.{0!s}'.format(login_status[12:-1]))
         if username:
             self.site._username = [username, username]
         if not params:
@@ -227,7 +222,7 @@ def process_entries(cache_path, func, use_accesstime=None, output_func=None,
         cache_path = os.path.join(pywikibot.config2.base_dir, 'apicache')
 
     if not os.path.exists(cache_path):
-        pywikibot.error('%s: no such file or directory' % cache_path)
+        pywikibot.error('{0!s}: no such file or directory'.format(cache_path))
         return
 
     if os.path.isdir(cache_path):
@@ -263,16 +258,14 @@ def process_entries(cache_path, func, use_accesstime=None, output_func=None,
         try:
             entry.parse_key()
         except ParseError:
-            pywikibot.error(u'Problems parsing %s with key %s'
-                            % (entry.filename, entry.key))
+            pywikibot.error(u'Problems parsing {0!s} with key {1!s}'.format(entry.filename, entry.key))
             pywikibot.exception()
             continue
 
         try:
             entry._rebuild()
         except Exception as e:
-            pywikibot.error(u'Problems loading %s with key %s, %r'
-                            % (entry.filename, entry.key, entry._parsed_key))
+            pywikibot.error(u'Problems loading {0!s} with key {1!s}, {2!r}'.format(entry.filename, entry.key, entry._parsed_key))
             pywikibot.exception(e, tb=True)
             continue
 
@@ -444,7 +437,7 @@ def main():
 
     for cache_path in cache_paths:
         if len(cache_paths) > 1:
-            pywikibot.output(u'Processing %s' % cache_path)
+            pywikibot.output(u'Processing {0!s}'.format(cache_path))
         process_entries(cache_path, filter_func, output_func=output_func,
                         action_func=action_func)
 

--- a/scripts/maintenance/compat2core.py
+++ b/scripts/maintenance/compat2core.py
@@ -154,14 +154,14 @@ class ConvertBot(object):
             self.source = os.path.join('scripts', self.source)
             if os.path.exists(self.source):
                 break
-            pywikibot.output(u'%s does not exist. Please retry.' % self.source)
+            pywikibot.output(u'{0!s} does not exist. Please retry.'.format(self.source))
             self.source = None
 
     def get_dest(self):
         """Ask for destination script name."""
-        self.dest = u'%s-core.%s' % tuple(self.source.rsplit(u'.', 1))
+        self.dest = u'{0!s}-core.{1!s}'.format(*tuple(self.source.rsplit(u'.', 1)))
         if not self.warnonly and not pywikibot.input_yn(
-                u'Destination file is %s.' % self.dest,
+                u'Destination file is {0!s}.'.format(self.dest),
                 default=True, automatic_quit=False):
             pywikibot.output('Quitting...')
             exit()
@@ -184,7 +184,7 @@ class ConvertBot(object):
         for i, line in enumerate(g, start=1):
             for w in warnings:
                 if w[0] in line:
-                    pywikibot.warning(u'line %d: %s>>> %s\n' % (i, line, w[1]))
+                    pywikibot.warning(u'line {0:d}: {1!s}>>> {2!s}\n'.format(i, line, w[1]))
         g.close()
 
 

--- a/scripts/maintenance/make_i18n_dict.py
+++ b/scripts/maintenance/make_i18n_dict.py
@@ -82,11 +82,11 @@ class i18nBot(object):
         print("# -*- coding: utf-8 -*-")
         print("msg = {")
         for code in keys:
-            print("    '%s': {" % code)
+            print("    '{0!s}': {{".format(code))
             for msg in sorted(self.messages.values()):
-                label = "%s-%s" % (self.scriptname, msg)
+                label = "{0!s}-{1!s}".format(self.scriptname, msg)
                 if label in self.dict[code]:
-                    print("        '%s': u'%s'," % (label,
+                    print("        '{0!s}': u'{1!s}',".format(label,
                                                     self.dict[code][label]))
             print("    },")
         print("};")
@@ -99,19 +99,18 @@ class i18nBot(object):
         if newmsg is None:
             newmsg = oldmsg
         for code in keys:
-            label = "%s-%s" % (self.scriptname, newmsg)
+            label = "{0!s}-{1!s}".format(self.scriptname, newmsg)
             if code == 'qqq':
                 if code not in self.dict:
                     self.dict[code] = {}
                 self.dict[code][label] = (
-                    u'Edit summary for message %s of %s report'
-                    % (newmsg, self.scriptname))
+                    u'Edit summary for message {0!s} of {1!s} report'.format(newmsg, self.scriptname))
             elif code != 'commons':
                 if code not in self.dict:
                     self.dict[code] = {}
                 self.dict[code][label] = msg[code]
         if 'en' not in keys:
-            print('WARNING: "en" key missing for message %s' % newmsg)
+            print('WARNING: "en" key missing for message {0!s}'.format(newmsg))
 
     def run(self, quiet=False):
         """
@@ -141,7 +140,7 @@ class i18nBot(object):
         if not os.path.exists(json_dir):
             os.makedirs(json_dir)
         for lang in self.dict:
-            file_name = os.path.join(json_dir, '%s.json' % lang)
+            file_name = os.path.join(json_dir, '{0!s}.json'.format(lang))
             if os.path.isfile(file_name):
                 with codecs.open(file_name, 'r', 'utf-8') as json_file:
                     new_dict = json.loads(json_file.read())

--- a/scripts/maintenance/wikimedia_sites.py
+++ b/scripts/maintenance/wikimedia_sites.py
@@ -47,7 +47,7 @@ exceptions = ['www']
 def update_family(families):
     """Update family files."""
     for family in families or familiesDict.keys():
-        pywikibot.output('\nChecking family %s:' % family)
+        pywikibot.output('\nChecking family {0!s}:'.format(family))
 
         original = Family.load(family).languages_by_size
         obsolete = Family.load(family).obsolete
@@ -66,8 +66,7 @@ def update_family(families):
         # put the missing languages to the right place
         missing = original != new and set(original) - set(new)
         if missing:
-            pywikibot.output(u"WARNING: ['%s'] not listed at wikistats."
-                             % "', '".join(missing))
+            pywikibot.output(u"WARNING: ['{0!s}'] not listed at wikistats.".format("', '".join(missing)))
             index = {}
             for code in missing:
                 index[original.index(code)] = code
@@ -84,15 +83,15 @@ def update_family(families):
             line = ' ' * 11
             for code in new:
                 if len(line) + len(code) <= 76:
-                    line += u" '%s'," % code
+                    line += u" '{0!s}',".format(code)
                 else:
-                    text += u'%s\r\n' % line
+                    text += u'{0!s}\r\n'.format(line)
                     line = ' ' * 11
-                    line += u" '%s'," % code
-            text += u'%s\r\n' % line
+                    line += u" '{0!s}',".format(code)
+            text += u'{0!s}\r\n'.format(line)
             text += u'        ]'
             pywikibot.output(text)
-            family_file_name = 'pywikibot/families/%s_family.py' % family
+            family_file_name = 'pywikibot/families/{0!s}_family.py'.format(family)
             family_file = codecs.open(family_file_name, 'r', 'utf8')
             family_text = family_file.read()
             old = re.findall(r'(?msu)^ {8}self.languages_by_size.+?\]',

--- a/scripts/makecat.py
+++ b/scripts/makecat.py
@@ -115,7 +115,7 @@ def asktoadd(pl):
         return
     ctoshow = 500
     pywikibot.output(u'')
-    pywikibot.output(u"==%s==" % pl.title())
+    pywikibot.output(u"=={0!s}==".format(pl.title()))
     while True:
         # TODO: Use pywikibot.inputChoice?
         # (needs the support for 'other options')
@@ -136,7 +136,7 @@ def asktoadd(pl):
             include(pl)
             break
         elif answer == 'n':
-            excludefile.write('%s\n' % pl.title())
+            excludefile.write('{0!s}\n'.format(pl.title()))
             break
         elif answer == 'i':
             break
@@ -166,13 +166,12 @@ def asktoadd(pl):
                 pywikibot.output(u"Page does not exist; not added.")
             break
         elif answer == 'l':
-            pywikibot.output(u"Number of pages still to check: %s"
-                             % len(tocheck))
+            pywikibot.output(u"Number of pages still to check: {0!s}".format(len(tocheck)))
             pywikibot.output(u"Pages to be checked:")
             pywikibot.output(u" - ".join(page.title() for page in tocheck))
-            pywikibot.output(u"==%s==" % pl.title())
+            pywikibot.output(u"=={0!s}==".format(pl.title()))
         elif answer == 't':
-            pywikibot.output(u"==%s==" % pl.title())
+            pywikibot.output(u"=={0!s}==".format(pl.title()))
             try:
                 pywikibot.output(u'' + pl.get(get_redirect=True)[0:ctoshow])
             except pywikibot.NoPage:
@@ -213,8 +212,7 @@ try:
     mysite = pywikibot.Site()
     pywikibot.setAction(i18n.twtranslate(mysite, 'makecat-create', {'cat': workingcatname}))
     workingcat = pywikibot.Category(mysite,
-                                    u'%s:%s'
-                                    % (mysite.namespaces.CATEGORY,
+                                    u'{0!s}:{1!s}'.format(mysite.namespaces.CATEGORY,
                                        workingcatname))
     filename = pywikibot.config.datafilepath(
         'category', workingcatname.encode('ascii', 'xmlcharrefreplace') + '_exclude.txt')
@@ -256,9 +254,8 @@ try:
     articles = list(workingcat.articles(content=True))
     if not articles:
         pywikibot.output(
-            u"Category %s does not exist or is empty. Which page to start with?"
-            % workingcatname)
-        answer = pywikibot.input(u"(Default is [[%s]]):" % workingcatname)
+            u"Category {0!s} does not exist or is empty. Which page to start with?".format(workingcatname))
+        answer = pywikibot.input(u"(Default is [[{0!s}]]):".format(workingcatname))
         if not answer:
             answer = workingcatname
         pywikibot.output(u'' + answer)

--- a/scripts/movepages.py
+++ b/scripts/movepages.py
@@ -86,8 +86,7 @@ class MovePagesBot(MultipleSitesBot):
             msg = self.getOption('summary')
             if not msg:
                 msg = i18n.twtranslate(page.site, 'movepages-moving')
-            pywikibot.output(u'Moving page %s to [[%s]]'
-                             % (page.title(asLink=True),
+            pywikibot.output(u'Moving page {0!s} to [[{1!s}]]'.format(page.title(asLink=True),
                                 newPageTitle))
             page.move(newPageTitle, reason=msg, movetalkpage=self.getOption('movetalkpage'),
                       deleteAndMove=self.getOption('noredirect'))
@@ -98,24 +97,22 @@ class MovePagesBot(MultipleSitesBot):
         """Treat a single page."""
         self.current_page = page
         if self.getOption('skipredirects') and page.isRedirectPage():
-            pywikibot.output(u'Page %s is a redirect; skipping.' % page.title())
+            pywikibot.output(u'Page {0!s} is a redirect; skipping.'.format(page.title()))
             return
         pagetitle = page.title(withNamespace=False)
         namesp = page.site.namespace(page.namespace())
         if self.appendAll:
-            newPageTitle = (u'%s%s%s'
-                            % (self.pagestart, pagetitle, self.pageend))
+            newPageTitle = (u'{0!s}{1!s}{2!s}'.format(self.pagestart, pagetitle, self.pageend))
             if not self.noNamespace and namesp:
-                newPageTitle = (u'%s:%s' % (namesp, newPageTitle))
+                newPageTitle = (u'{0!s}:{1!s}'.format(namesp, newPageTitle))
         elif self.regexAll:
             newPageTitle = self.regex.sub(self.replacePattern, pagetitle)
             if not self.noNamespace and namesp:
-                newPageTitle = (u'%s:%s' % (namesp, newPageTitle))
+                newPageTitle = (u'{0!s}:{1!s}'.format(namesp, newPageTitle))
         if self.getOption('prefix'):
-            newPageTitle = (u'%s%s' % (self.getOption('prefix'), pagetitle))
+            newPageTitle = (u'{0!s}{1!s}'.format(self.getOption('prefix'), pagetitle))
         if self.getOption('prefix') or self.appendAll or self.regexAll:
-            if self.user_confirm('Change the page title to "%s"?'
-                                 % newPageTitle):
+            if self.user_confirm('Change the page title to "{0!s}"?'.format(newPageTitle)):
                 self.moveOne(page, newPageTitle)
         else:
             choice = pywikibot.input_choice(u'What do you want to do?',
@@ -129,18 +126,16 @@ class MovePagesBot(MultipleSitesBot):
             elif choice == 'a':
                 self.pagestart = pywikibot.input(u'Append this to the start:')
                 self.pageend = pywikibot.input(u'Append this to the end:')
-                newPageTitle = (u'%s%s%s'
-                                % (self.pagestart, pagetitle, self.pageend))
+                newPageTitle = (u'{0!s}{1!s}{2!s}'.format(self.pagestart, pagetitle, self.pageend))
                 if namesp:
                     if pywikibot.input_yn(u'Do you want to remove the '
                                           'namespace prefix "%s:"?' % namesp,
                                           automatic_quit=False):
                         self.noNamespace = True
                     else:
-                        newPageTitle = (u'%s:%s' % (namesp, newPageTitle))
+                        newPageTitle = (u'{0!s}:{1!s}'.format(namesp, newPageTitle))
                 choice2 = pywikibot.input_choice(
-                    u'Change the page title to "%s"?'
-                    % newPageTitle, [('yes', 'y'), ('no', 'n'), ('all', 'a')])
+                    u'Change the page title to "{0!s}"?'.format(newPageTitle), [('yes', 'y'), ('no', 'n'), ('all', 'a')])
                 if choice2 == 'y':
                     self.moveOne(page, newPageTitle)
                 elif choice2 == 'a':
@@ -165,8 +160,7 @@ class MovePagesBot(MultipleSitesBot):
                         newPageTitle = self.regex.sub(self.replacePattern,
                                                       page.title())
                 choice2 = pywikibot.input_choice(
-                    u'Change the page title to "%s"?'
-                    % newPageTitle, [('yes', 'y'), ('no', 'n'), ('all', 'a')])
+                    u'Change the page title to "{0!s}"?'.format(newPageTitle), [('yes', 'y'), ('no', 'n'), ('all', 'a')])
                 if choice2 == 'y':
                     self.moveOne(page, newPageTitle)
                 elif choice2 == 'a':
@@ -213,7 +207,7 @@ def main(*args):
                     oldName1 = page.title()
             if oldName1:
                 pywikibot.warning(
-                    u'file %s contains odd number of links' % filename)
+                    u'file {0!s} contains odd number of links'.format(filename))
         elif arg == '-noredirect':
             options['noredirect'] = True
         elif arg == '-notalkpage':
@@ -224,14 +218,14 @@ def main(*args):
             options['skipredirects'] = True
         elif arg.startswith('-from:'):
             if oldName:
-                pywikibot.warning(u'-from:%s without -to:' % oldName)
+                pywikibot.warning(u'-from:{0!s} without -to:'.format(oldName))
             oldName = arg[len('-from:'):]
         elif arg.startswith('-to:'):
             if oldName:
                 fromToPairs.append([oldName, arg[len('-to:'):]])
                 oldName = None
             else:
-                pywikibot.warning(u'%s without -from' % arg)
+                pywikibot.warning(u'{0!s} without -from'.format(arg))
         elif arg.startswith('-prefix'):
             if len(arg) == len('-prefix'):
                 options['prefix'] = pywikibot.input(u'Enter the prefix:')
@@ -246,7 +240,7 @@ def main(*args):
             genFactory.handleArg(arg)
 
     if oldName:
-        pywikibot.warning(u'-from:%s without -to:' % oldName)
+        pywikibot.warning(u'-from:{0!s} without -to:'.format(oldName))
     site = pywikibot.Site()
     for pair in fromToPairs:
         page = pywikibot.Page(site, pair[0])

--- a/scripts/newitem.py
+++ b/scripts/newitem.py
@@ -65,7 +65,7 @@ class NewItemRobot(WikidataBot):
     def treat(self, page, item):
         """Treat page/item."""
         if item and item.exists():
-            pywikibot.output(u'%s already has an item: %s.' % (page, item))
+            pywikibot.output(u'{0!s} already has an item: {1!s}.'.format(page, item))
             if self.getOption('touch'):
                 pywikibot.output(u'Doing a null edit on the page.')
                 page.put(page.text)
@@ -74,18 +74,16 @@ class NewItemRobot(WikidataBot):
         self.current_page = page
 
         if page.isRedirectPage():
-            pywikibot.output(u'%s is a redirect page. Skipping.' % page)
+            pywikibot.output(u'{0!s} is a redirect page. Skipping.'.format(page))
             return
         if page.editTime() > self.lastEditBefore:
             pywikibot.output(
-                u'Last edit on %s was on %s.\nToo recent. Skipping.'
-                % (page, page.editTime().isoformat()))
+                u'Last edit on {0!s} was on {1!s}.\nToo recent. Skipping.'.format(page, page.editTime().isoformat()))
             return
 
         if page.oldest_revision.timestamp > self.pageAgeBefore:
             pywikibot.output(
-                u'Page creation of %s on %s is too recent. Skipping.'
-                % (page, page.editTime().isoformat()))
+                u'Page creation of {0!s} on {1!s} is too recent. Skipping.'.format(page, page.editTime().isoformat()))
             return
 
         if page.langlinks():
@@ -96,8 +94,7 @@ class NewItemRobot(WikidataBot):
             return
 
         # FIXME: i18n
-        summary = (u'Bot: New item with sitelink from %s'
-                   % page.title(asLink=True, insite=self.repo))
+        summary = (u'Bot: New item with sitelink from {0!s}'.format(page.title(asLink=True, insite=self.repo)))
 
         data = {'sitelinks':
                 {page.site.dbName():

--- a/scripts/noreferences.py
+++ b/scripts/noreferences.py
@@ -538,20 +538,18 @@ class NoReferencesBot(Bot):
 
         # Is there an existing section where we can add the references tag?
         for section in i18n.translate(self.site, referencesSections):
-            sectionR = re.compile(r'\r?\n=+ *%s *=+ *\r?\n' % section)
+            sectionR = re.compile(r'\r?\n=+ *{0!s} *=+ *\r?\n'.format(section))
             index = 0
             while index < len(oldText):
                 match = sectionR.search(oldText, index)
                 if match:
                     if textlib.isDisabled(oldText, match.start()):
                         pywikibot.output(
-                            'Existing  %s section is commented out, skipping.'
-                            % section)
+                            'Existing  {0!s} section is commented out, skipping.'.format(section))
                         index = match.end()
                     else:
                         pywikibot.output(
-                            'Adding references tag to existing %s section...\n'
-                            % section)
+                            'Adding references tag to existing {0!s} section...\n'.format(section))
                         newText = (
                             oldText[:match.end()] + u'\n' +
                             self.referencesText + u'\n' +
@@ -564,8 +562,7 @@ class NoReferencesBot(Bot):
         # Create a new section for the references tag
         for section in i18n.translate(self.site, placeBeforeSections):
             # Find out where to place the new section
-            sectionR = re.compile(r'\r?\n(?P<ident>=+) *%s *(?P=ident) *\r?\n'
-                                  % section)
+            sectionR = re.compile(r'\r?\n(?P<ident>=+) *{0!s} *(?P=ident) *\r?\n'.format(section))
             index = 0
             while index < len(oldText):
                 match = sectionR.search(oldText, index)
@@ -577,8 +574,7 @@ class NoReferencesBot(Bot):
                         index = match.end()
                     else:
                         pywikibot.output(
-                            u'Adding references section before %s section...\n'
-                            % section)
+                            u'Adding references section before {0!s} section...\n'.format(section))
                         index = match.start()
                         ident = match.group('ident')
                         return self.createReferenceSection(oldText, index,
@@ -595,7 +591,7 @@ class NoReferencesBot(Bot):
         # At the end, look at the length of the temp text. That's the position
         # where we'll insert the references section.
         catNamespaces = '|'.join(self.site.namespaces.CATEGORY)
-        categoryPattern = r'\[\[\s*(%s)\s*:[^\n]*\]\]\s*' % catNamespaces
+        categoryPattern = r'\[\[\s*({0!s})\s*:[^\n]*\]\]\s*'.format(catNamespaces)
         interwikiPattern = r'\[\[([a-zA-Z\-]+)\s?:([^\[\]\n]*)\]\]\s*'
         # won't work with nested templates
         # the negative lookahead assures that we'll match the last template
@@ -606,8 +602,7 @@ class NoReferencesBot(Bot):
         # so templatePattern must be fixed
         templatePattern = r'\r?\n{{((?!}}).)+?}}\s*'
         commentPattern = r'<!--((?!-->).)*?-->\s*'
-        metadataR = re.compile(r'(\r?\n)?(%s|%s|%s|%s)$'
-                               % (categoryPattern, interwikiPattern,
+        metadataR = re.compile(r'(\r?\n)?({0!s}|{1!s}|{2!s}|{3!s})$'.format(categoryPattern, interwikiPattern,
                                   templatePattern, commentPattern), re.DOTALL)
         tmpText = oldText
         while True:
@@ -626,9 +621,9 @@ class NoReferencesBot(Bot):
     def createReferenceSection(self, oldText, index, ident='=='):
         """Create a reference section and insert it into the given text."""
         if self.site.code in noTitleRequired:
-            newSection = u'\n%s\n' % (self.referencesText)
+            newSection = u'\n{0!s}\n'.format((self.referencesText))
         else:
-            newSection = u'\n%s %s %s\n%s\n' % (ident,
+            newSection = u'\n{0!s} {1!s} {2!s}\n{3!s}\n'.format(ident,
                                                 i18n.translate(
                                                     self.site,
                                                     referencesSections)[0],
@@ -642,39 +637,32 @@ class NoReferencesBot(Bot):
             try:
                 text = page.text
             except pywikibot.NoPage:
-                pywikibot.output(u"Page %s does not exist?!"
-                                 % page.title(asLink=True))
+                pywikibot.output(u"Page {0!s} does not exist?!".format(page.title(asLink=True)))
                 continue
             except pywikibot.IsRedirectPage:
-                pywikibot.output(u"Page %s is a redirect; skipping."
-                                 % page.title(asLink=True))
+                pywikibot.output(u"Page {0!s} is a redirect; skipping.".format(page.title(asLink=True)))
                 continue
             except pywikibot.LockedPage:
-                pywikibot.output(u"Page %s is locked?!"
-                                 % page.title(asLink=True))
+                pywikibot.output(u"Page {0!s} is locked?!".format(page.title(asLink=True)))
                 continue
             if page.isDisambig():
-                pywikibot.output(u"Page %s is a disambig; skipping."
-                                 % page.title(asLink=True))
+                pywikibot.output(u"Page {0!s} is a disambig; skipping.".format(page.title(asLink=True)))
                 continue
             if self.site.sitename == 'wikipedia:en' and page.isIpEdit():
                 pywikibot.output(
-                    u"Page %s is edited by IP. Possible vandalized"
-                    % page.title(asLink=True))
+                    u"Page {0!s} is edited by IP. Possible vandalized".format(page.title(asLink=True)))
                 continue
             if self.lacksReferences(text):
                 newText = self.addReferences(text)
                 try:
                     self.userPut(page, page.text, newText, summary=self.comment)
                 except pywikibot.EditConflict:
-                    pywikibot.output(u'Skipping %s because of edit conflict'
-                                     % page.title())
+                    pywikibot.output(u'Skipping {0!s} because of edit conflict'.format(page.title()))
                 except pywikibot.SpamfilterError as e:
                     pywikibot.output(
-                        u'Cannot change %s because of blacklist entry %s'
-                        % (page.title(), e.url))
+                        u'Cannot change {0!s} because of blacklist entry {1!s}'.format(page.title(), e.url))
                 except pywikibot.LockedPage:
-                    pywikibot.output(u'Skipping %s (locked page)' % page.title())
+                    pywikibot.output(u'Skipping {0!s} (locked page)'.format(page.title()))
 
 
 def main(*args):
@@ -715,7 +703,7 @@ def main(*args):
         except:
             pass
         else:
-            cat = pywikibot.Category(site, "%s:%s" % (
+            cat = pywikibot.Category(site, "{0!s}:{1!s}".format(
                 site.namespaces.CATEGORY, cat))
             gen = cat.articles(namespaces=genFactory.namespaces or [0])
     if gen:

--- a/scripts/nowcommons.py
+++ b/scripts/nowcommons.py
@@ -259,8 +259,7 @@ class NowCommonsDeleteBot(Bot):
                 pywikibot.output(color_format(
                     '\n\n>>> {lightpurple}{0}{default} <<<',
                     image_local))
-                pywikibot.output(u'Local: %s\nCommons: %s\n'
-                                 % (url_local, url_commons))
+                pywikibot.output(u'Local: {0!s}\nCommons: {1!s}\n'.format(url_local, url_commons))
                 webbrowser.open(url_local, 0, 1)
                 webbrowser.open(url_commons, 0, 1)
                 if image_local.split('Image:')[1] == image_commons:
@@ -351,8 +350,7 @@ class NowCommonsDeleteBot(Bot):
                 if not filenameOnCommons and not self.getOption('use_hash'):
                     pywikibot.output(u'NowCommons template not found.')
                     continue
-                commonsImagePage = pywikibot.FilePage(commons, 'Image:%s'
-                                                      % filenameOnCommons)
+                commonsImagePage = pywikibot.FilePage(commons, 'Image:{0!s}'.format(filenameOnCommons))
                 if (localImagePage.title(withNamespace=False) ==
                         commonsImagePage.title(withNamespace=False) and
                         self.getOption('use_hash')):
@@ -400,9 +398,8 @@ class NowCommonsDeleteBot(Bot):
                                 if usingPages > 0 and self.getOption('use_hash'):
                                     # just an enter
                                     pywikibot.input(
-                                        u'There are still %s pages with this \
-                                        image, confirm the manual removal from them please.'
-                                        % usingPages)
+                                        u'There are still {0!s} pages with this \
+                                        image, confirm the manual removal from them please.'.format(usingPages))
 
                         else:
                             pywikibot.output(u'Please change them manually.')
@@ -439,17 +436,15 @@ class NowCommonsDeleteBot(Bot):
                                     'information?',
                                     default=False, automatic_quit=False):
                                 localImagePage.delete(
-                                    '%s [[:commons:Image:%s]]'
-                                    % (comment, filenameOnCommons), prompt=False)
+                                    '{0!s} [[:commons:Image:{1!s}]]'.format(comment, filenameOnCommons), prompt=False)
                         else:
                             localImagePage.delete(
-                                comment + ' [[:commons:Image:%s]]'
-                                % filenameOnCommons, prompt=False)
+                                comment + ' [[:commons:Image:{0!s}]]'.format(filenameOnCommons), prompt=False)
                     else:
                         pywikibot.output(
                             u'The image is not identical to the one on Commons.')
             except (pywikibot.NoPage, pywikibot.IsRedirectPage) as e:
-                pywikibot.output(u'%s' % e[0])
+                pywikibot.output(u'{0!s}'.format(e[0]))
                 continue
 
 

--- a/scripts/pagefromfile.py
+++ b/scripts/pagefromfile.py
@@ -136,7 +136,7 @@ class PageFromFileRobot(Bot):
             mysite, 'pagefromfile-msg_top')
         comment_bottom = comment + " - " + i18n.twtranslate(
             mysite, 'pagefromfile-msg_bottom')
-        comment_force = "%s *** %s ***" % (
+        comment_force = "{0!s} *** {1!s} ***".format(
             comment, i18n.twtranslate(mysite, 'pagefromfile-msg_force'))
 
         # Remove trailing newlines (cause troubles when creating redirects)
@@ -144,14 +144,14 @@ class PageFromFileRobot(Bot):
 
         if page.exists():
             if not self.getOption('redirect') and page.isRedirectPage():
-                pywikibot.output(u"Page %s is redirect, skipping!" % title)
+                pywikibot.output(u"Page {0!s} is redirect, skipping!".format(title))
                 return
             pagecontents = page.get(get_redirect=True)
             nocontent = self.getOption('nocontent')
             if nocontent and (
                     nocontent in pagecontents or
                     nocontent.lower() in pagecontents):
-                pywikibot.output('Page has %s so it is skipped' % nocontent)
+                pywikibot.output('Page has {0!s} so it is skipped'.format(nocontent))
                 return
             if self.getOption('append'):
                 separator = self.getOption('append')[1]
@@ -167,11 +167,10 @@ class PageFromFileRobot(Bot):
                                  title, self.getOption('append')[0]))
                 contents = above + separator + below
             elif self.getOption('force'):
-                pywikibot.output(u"Page %s already exists, ***overwriting!"
-                                 % title)
+                pywikibot.output(u"Page {0!s} already exists, ***overwriting!".format(title))
                 comment = comment_force
             else:
-                pywikibot.output(u"Page %s already exists, not adding!" % title)
+                pywikibot.output(u"Page {0!s} already exists, not adding!".format(title))
                 return
         else:
             if self.getOption('autosummary'):
@@ -212,7 +211,7 @@ class PageFromFileReader(object):
 
     def run(self):
         """Read file and yield page title and content."""
-        pywikibot.output('\n\nReading \'%s\'...' % self.filename)
+        pywikibot.output('\n\nReading \'{0!s}\'...'.format(self.filename))
         try:
             with codecs.open(self.filename, 'r',
                              encoding=config.textfile_encoding) as f:
@@ -329,11 +328,11 @@ def main(*args):
         elif arg == '-showdiff':
             options['showdiff'] = True
         else:
-            pywikibot.output(u"Disregarding unknown argument %s." % arg)
+            pywikibot.output(u"Disregarding unknown argument {0!s}.".format(arg))
 
     failed_filename = False
     while not os.path.isfile(filename):
-        pywikibot.output('\nFile \'%s\' does not exist. ' % filename)
+        pywikibot.output('\nFile \'{0!s}\' does not exist. '.format(filename))
         _input = pywikibot.input(
             'Please enter the file name [q to quit]:')
         if _input == 'q':

--- a/scripts/panoramiopicker.py
+++ b/scripts/panoramiopicker.py
@@ -113,18 +113,16 @@ def getFilename(photoInfo, site=None,
     else:
         title = u''
 
-    if pywikibot.Page(site, u'File:%s - %s - %s.jpg'
-                      % (project, username, title)).exists():
+    if pywikibot.Page(site, u'File:{0!s} - {1!s} - {2!s}.jpg'.format(project, username, title)).exists():
         i = 1
         while True:
-            if (pywikibot.Page(site, u'File:%s - %s - %s (%s).jpg'
-                               % (project, username, title, str(i))).exists()):
+            if (pywikibot.Page(site, u'File:{0!s} - {1!s} - {2!s} ({3!s}).jpg'.format(project, username, title, str(i))).exists()):
                 i += 1
             else:
-                return u'%s - %s - %s (%s).jpg' % (project, username, title,
+                return u'{0!s} - {1!s} - {2!s} ({3!s}).jpg'.format(project, username, title,
                                                    str(i))
     else:
-        return u'%s - %s - %s.jpg' % (project, username, title)
+        return u'{0!s} - {1!s} - {2!s}.jpg'.format(project, username, title)
 
 
 def cleanUpTitle(title):
@@ -185,7 +183,7 @@ def getDescription(photoInfo, panoramioreview=False, reviewer='',
     desc += u'\n'
     cats = u''
     if addCategory:
-        desc += u'\n[[Category:%s]]\n' % (addCategory,)
+        desc += u'\n[[Category:{0!s}]]\n'.format(addCategory)
         cats = True
 
     # Get categories based on location
@@ -194,7 +192,7 @@ def getDescription(photoInfo, panoramioreview=False, reviewer='',
                                                photoInfo.get(u'longitude'))
         cats = imagerecat.applyAllFilters(cats)
         for cat in cats:
-            desc += u'[[Category:%s]]\n' % (cat,)
+            desc += u'[[Category:{0!s}]]\n'.format(cat)
     if not cats:
         desc += u'{{subst:Unc}}\n'
 
@@ -214,7 +212,7 @@ def processPhoto(photoInfo, panoramioreview=False, reviewer='',
         # Don't upload duplicate images, should add override option
         duplicates = findDuplicateImages(photo, site=site)
         if duplicates:
-            pywikibot.output(u'Found duplicate image at %s' % duplicates.pop())
+            pywikibot.output(u'Found duplicate image at {0!s}'.format(duplicates.pop()))
         else:
             filename = getFilename(photoInfo, site=site)
             pywikibot.output(filename)

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -102,7 +102,7 @@ class PatrolBot(SingleSiteBot):
         else:
             local_whitelist_subpage_name = pywikibot.translate(
                 self.site, self.whitelist_subpage_name, fallback=True)
-            self.whitelist_pagename = u'%s:%s/%s' % (
+            self.whitelist_pagename = u'{0!s}:{1!s}/{2!s}'.format(
                                       self.site.namespace(2),
                                       self.site.username(),
                                       local_whitelist_subpage_name)
@@ -137,7 +137,7 @@ class PatrolBot(SingleSiteBot):
                                         self.whitelist_pagename)
 
         if not self.whitelist:
-            pywikibot.output(u'Loading %s' % self.whitelist_pagename)
+            pywikibot.output(u'Loading {0!s}'.format(self.whitelist_pagename))
 
         try:
             if self.whitelist_ts:
@@ -166,12 +166,12 @@ class PatrolBot(SingleSiteBot):
             # cascade if there isnt a whitelist to fallback on
             if not self.whitelist:
                 raise
-            pywikibot.error(u'%s' % e)
+            pywikibot.error(u'{0!s}'.format(e))
 
     def in_list(self, pagelist, title):
         """Check if title present in pagelist."""
         if pywikibot.config.verbose_output:
-            pywikibot.output(u'Checking whitelist for: %s' % title)
+            pywikibot.output(u'Checking whitelist for: {0!s}'.format(title))
 
         # quick check for exact match
         if title in pagelist:
@@ -185,7 +185,7 @@ class PatrolBot(SingleSiteBot):
 
         for item in pagelist:
             if pywikibot.config.verbose_output:
-                pywikibot.output(u'checking against whitelist item = %s' % item)
+                pywikibot.output(u'checking against whitelist item = {0!s}'.format(item))
 
             if isinstance(item, PatrolRule):
                 if pywikibot.config.verbose_output:
@@ -245,7 +245,7 @@ class PatrolBot(SingleSiteBot):
                     # the user will be the target of subsequent rules
                     current_user = obj.title
                     if pywikibot.config.verbose_output:
-                        pywikibot.output(u'Whitelist user: %s' % current_user)
+                        pywikibot.output(u'Whitelist user: {0!s}'.format(current_user))
                     continue
                 else:
                     page = obj.canonical_title()
@@ -254,11 +254,11 @@ class PatrolBot(SingleSiteBot):
                     if not user or current_user == user:
                         if self.is_wikisource_author_page(page):
                             if pywikibot.config.verbose_output:
-                                pywikibot.output(u'Whitelist author: %s' % page)
+                                pywikibot.output(u'Whitelist author: {0!s}'.format(page))
                             page = LinkedPagesRule(page)
                         else:
                             if pywikibot.config.verbose_output:
-                                pywikibot.output(u'Whitelist page: %s' % page)
+                                pywikibot.output(u'Whitelist page: {0!s}'.format(page))
                         if pywikibot.config.verbose_output:
                             pywikibot.output('Adding {0}:{1}'.format(current_user, page))
                         whitelist[current_user].append(page)
@@ -266,7 +266,7 @@ class PatrolBot(SingleSiteBot):
                         pywikibot.output(u'Discarding whitelist page for '
                                          u'another user: %s' % page)
                 else:
-                    raise Exception(u'No user set for page %s' % page)
+                    raise Exception(u'No user set for page {0!s}'.format(page))
 
         return dict(whitelist)
 
@@ -282,12 +282,11 @@ class PatrolBot(SingleSiteBot):
             pass
         if author_ns:
             author_ns_prefix = self.site.namespace(author_ns)
-        pywikibot.debug(u'Author ns: %d; name: %s'
-                        % (author_ns, author_ns_prefix), _logger)
+        pywikibot.debug(u'Author ns: {0:d}; name: {1!s}'.format(author_ns, author_ns_prefix), _logger)
         if title.find(author_ns_prefix + ':') == 0:
             if pywikibot.config.verbose_output:
                 author_page_name = title[len(author_ns_prefix) + 1:]
-                pywikibot.output(u'Found author %s' % author_page_name)
+                pywikibot.output(u'Found author {0!s}'.format(author_page_name))
             return True
 
     def run(self, feed=None):
@@ -321,23 +320,20 @@ class PatrolBot(SingleSiteBot):
                 self.repeat_start_ts = time.time()
 
             if pywikibot.config.verbose_output or self.getOption('ask'):
-                pywikibot.output(u'User %s has created or modified page %s'
-                                 % (username, title))
+                pywikibot.output(u'User {0!s} has created or modified page {1!s}'.format(username, title))
 
             if self.getOption('autopatroluserns') and (page['ns'] == 2 or
                                                        page['ns'] == 3):
                 # simple rule to whitelist any user editing their own userspace
                 if title.partition(':')[2].split('/')[0].startswith(username):
                     if pywikibot.config.verbose_output:
-                        pywikibot.output(u'%s is whitelisted to modify %s'
-                                         % (username, title))
+                        pywikibot.output(u'{0!s} is whitelisted to modify {1!s}'.format(username, title))
                     choice = True
 
             if not choice and username in self.whitelist:
                 if self.in_list(self.whitelist[username], title):
                     if pywikibot.config.verbose_output:
-                        pywikibot.output(u'%s is whitelisted to modify %s'
-                                         % (username, title))
+                        pywikibot.output(u'{0!s} is whitelisted to modify {1!s}'.format(username, title))
                     choice = True
 
             if self.getOption('ask'):
@@ -349,8 +345,7 @@ class PatrolBot(SingleSiteBot):
                 # list() iterates over patrol() which returns a generator
                 list(self.site.patrol(rcid))
                 self.patrol_counter = self.patrol_counter + 1
-                pywikibot.output(u'Patrolled %s (rcid %d) by user %s'
-                                 % (title, rcid, username))
+                pywikibot.output(u'Patrolled {0!s} (rcid {1:d}) by user {2!s}'.format(title, rcid, username))
             else:
                 if pywikibot.config.verbose_output:
                     pywikibot.output(u'Skipped')
@@ -361,17 +356,15 @@ class PatrolBot(SingleSiteBot):
             self.rc_item_counter = self.rc_item_counter + 1
 
         except pywikibot.NoPage:
-            pywikibot.output(u'Page %s does not exist; skipping.'
-                             % title(asLink=True))
+            pywikibot.output(u'Page {0!s} does not exist; skipping.'.format(title(asLink=True)))
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u'Page %s is a redirect; skipping.'
-                             % title(asLink=True))
+            pywikibot.output(u'Page {0!s} is a redirect; skipping.'.format(title(asLink=True)))
 
 
 def title_match(prefix, title):
     """Match title substring with given prefix."""
     if pywikibot.config.verbose_output:
-        pywikibot.output(u'Matching %s to prefix %s' % (title, prefix))
+        pywikibot.output(u'Matching {0!s} to prefix {1!s}'.format(title, prefix))
     if title.startswith(prefix):
         if pywikibot.config.verbose_output:
             pywikibot.output(u'substr match')
@@ -425,7 +418,7 @@ class LinkedPagesRule(PatrolRule):
 
         if not self.linkedpages:
             if pywikibot.config.verbose_output:
-                pywikibot.output(u'loading page links on %s' % self.page_title)
+                pywikibot.output(u'loading page links on {0!s}'.format(self.page_title))
             p = pywikibot.Page(self.site, self.page_title)
             linkedpages = list()
             for linkedpage in p.linkedPages():
@@ -433,11 +426,11 @@ class LinkedPagesRule(PatrolRule):
 
             self.linkedpages = linkedpages
             if pywikibot.config.verbose_output:
-                pywikibot.output(u'Loaded %d page links' % len(linkedpages))
+                pywikibot.output(u'Loaded {0:d} page links'.format(len(linkedpages)))
 
         for p in self.linkedpages:
             if pywikibot.config.verbose_output:
-                pywikibot.output(u"Checking against '%s'" % p)
+                pywikibot.output(u"Checking against '{0!s}'".format(p))
             if title_match(p, page_title):
                 if pywikibot.config.verbose_output:
                     pywikibot.output(u'Matched.')
@@ -460,7 +453,7 @@ def api_feed_repeater(gen, delay=0, repeat=False, namespaces=None,
             else:
                 yield page[1]
         if repeat:
-            pywikibot.output(u'Sleeping for %d seconds' % delay)
+            pywikibot.output(u'Sleeping for {0:d} seconds'.format(delay))
             time.sleep(delay)
         else:
             break
@@ -509,7 +502,7 @@ def main(*args):
     site.login()
 
     if usercontribs:
-        pywikibot.output(u'Processing user: %s' % usercontribs)
+        pywikibot.output(u'Processing user: {0!s}'.format(usercontribs))
 
     if not newpages and not recentchanges and not usercontribs:
         if site.family.name == 'wikipedia':
@@ -536,8 +529,7 @@ def main(*args):
                                  user=usercontribs)
         bot.run(feed)
 
-    pywikibot.output(u'%d/%d patrolled'
-                     % (bot.patrol_counter, bot.rc_item_counter))
+    pywikibot.output(u'{0:d}/{1:d} patrolled'.format(bot.patrol_counter, bot.rc_item_counter))
 
 if __name__ == '__main__':
     main()

--- a/scripts/piper.py
+++ b/scripts/piper.py
@@ -84,7 +84,7 @@ class PiperBot(MultipleSitesBot, ExistingPageBot, NoRedirectPageBot):
         pipe.append(program.encode('ascii'), '--')
 
         # Create a temporary filename to save the piped stuff to
-        tempFilename = '%s.%s' % (tempfile.mktemp(), 'txt')
+        tempFilename = '{0!s}.{1!s}'.format(tempfile.mktemp(), 'txt')
         with pipe.open(tempFilename, 'w') as file:
             file.write(text)
 

--- a/scripts/protect.py
+++ b/scripts/protect.py
@@ -100,8 +100,7 @@ class ProtectionRobot(SingleSiteBot):
         """
         self.current_page = page
         if not self.user_confirm(
-                'Do you want to change the protection level of %s?'
-                % page.title(asLink=True, forceInterwiki=True)):
+                'Do you want to change the protection level of {0!s}?'.format(page.title(asLink=True, forceInterwiki=True))):
             return
         applicable = page.applicable_protections()
         protections = dict(
@@ -130,8 +129,7 @@ def check_protection_level(operation, level, levels, default=None):
                 num += 1
             if level == default:
                 default_char = first_char[-1]
-        choice = pywikibot.input_choice('Choice a protection level to %s:'
-                                        % operation, zip(levels, first_char),
+        choice = pywikibot.input_choice('Choice a protection level to {0!s}:'.format(operation), zip(levels, first_char),
                                         default=default_char)
 
         return levels[first_char.index(choice)]

--- a/scripts/redirect.py
+++ b/scripts/redirect.py
@@ -143,7 +143,7 @@ class RedirectGenerator(object):
             readPagesCount += 1
             # always print status message after 10000 pages
             if readPagesCount % 10000 == 0:
-                pywikibot.output(u'%i pages read...' % readPagesCount)
+                pywikibot.output(u'{0:d} pages read...'.format(readPagesCount))
             if len(self.namespaces) > 0:
                 if pywikibot.Page(self.site, entry.title).namespace() \
                         not in self.namespaces:
@@ -175,8 +175,7 @@ class RedirectGenerator(object):
                     source = pywikibot.Link(entry.title, self.site)
                     if target_link.anchor:
                         pywikibot.output(
-                            u'HINT: %s is a redirect with a pipelink.'
-                            % entry.title)
+                            u'HINT: {0!s} is a redirect with a pipelink.'.format(entry.title))
                     redict[space_to_underscore(source)] = (
                         space_to_underscore(target_link))
         if alsoGetPageTitles:
@@ -241,7 +240,7 @@ class RedirectGenerator(object):
                                             'pageids': apiQ})
             data = gen.submit()
             if 'error' in data:
-                raise RuntimeError("API query error: %s" % data)
+                raise RuntimeError("API query error: {0!s}".format(data))
             if data == [] or 'query' not in data:
                 raise RuntimeError("No results given.")
             redirects = {}
@@ -326,8 +325,7 @@ class RedirectGenerator(object):
                 # redirect as well
                 if num > self.offset and value in redict:
                     yield key
-                    pywikibot.output(u'\nChecking redirect %i of %i...'
-                                     % (num + 1, len(redict)))
+                    pywikibot.output(u'\nChecking redirect {0:d} of {1:d}...'.format(num + 1, len(redict)))
         elif self.page_title:
             yield self.page_title
         else:
@@ -344,9 +342,8 @@ class RedirectGenerator(object):
                  datetime.timedelta(0, self.offset * 3600))
         # self.offset hours ago
         offset_time = start.strftime("%Y%m%d%H%M%S")
-        pywikibot.output(u'Retrieving %s moved pages via API...'
-                         % (str(self.api_number)
-                            if self.api_number is not None else "all"))
+        pywikibot.output(u'Retrieving {0!s} moved pages via API...'.format((str(self.api_number)
+                            if self.api_number is not None else "all")))
         move_gen = self.site.logevents(logtype="move", start=offset_time)
         if self.api_number:
             move_gen.set_maximum_items(self.api_number)
@@ -417,22 +414,21 @@ class RedirectRobot(Bot):
         try:
             targetPage = redir_page.getRedirectTarget()
         except pywikibot.IsNotRedirectPage:
-            pywikibot.output(u'%s is not a redirect.' % redir_page.title())
+            pywikibot.output(u'{0!s} is not a redirect.'.format(redir_page.title()))
         except pywikibot.CircularRedirect:
-            pywikibot.output(u'%s is a circular redirect.' % redir_page.title())
+            pywikibot.output(u'{0!s} is a circular redirect.'.format(redir_page.title()))
         except pywikibot.NoPage:
-            pywikibot.output(u'%s doesn\'t exist.' % redir_page.title())
+            pywikibot.output(u'{0!s} doesn\'t exist.'.format(redir_page.title()))
         except pywikibot.InvalidTitle:
             pywikibot.exception()
         except pywikibot.InterwikiRedirectPage:
-            pywikibot.output('%s is on another site.' % redir_page.title())
+            pywikibot.output('{0!s} is on another site.'.format(redir_page.title()))
         else:
             try:
                 targetPage.get()
             except pywikibot.BadTitle as e:
                 pywikibot.warning(
-                    u'Redirect target %s is not a valid page title.'
-                    % str(e)[10:])
+                    u'Redirect target {0!s} is not a valid page title.'.format(str(e)[10:]))
                 pass
             except pywikibot.InvalidTitle:
                 pywikibot.exception()
@@ -446,14 +442,12 @@ class RedirectRobot(Bot):
                 if movedTarget:
                     if not movedTarget.exists():
                         # FIXME: Test to another move
-                        pywikibot.output(u'Target page %s does not exist'
-                                         % (movedTarget))
+                        pywikibot.output(u'Target page {0!s} does not exist'.format((movedTarget)))
                     elif redir_page == movedTarget:
                         pywikibot.output(
                             'Redirect to target page forms a redirect loop')
                     else:
-                        pywikibot.output(u'%s has been moved to %s'
-                                         % (redir_page, movedTarget))
+                        pywikibot.output(u'{0!s} has been moved to {1!s}'.format(redir_page, movedTarget))
                         reason = i18n.twtranslate(self.site,
                                                   'redirect-fix-broken-moved',
                                                   {'to': movedTarget.title(
@@ -462,7 +456,7 @@ class RedirectRobot(Bot):
                         redir_page.set_redirect_target(
                             movedTarget, keep_section=True, save=False)
                         pywikibot.showDiff(content, redir_page.text)
-                        pywikibot.output(u'Summary - %s' % reason)
+                        pywikibot.output(u'Summary - {0!s}'.format(reason))
                         if self.user_confirm(
                                 u'Redirect target %s has been moved to %s.\n'
                                 u'Do you want to fix %s?'
@@ -474,8 +468,7 @@ class RedirectRobot(Bot):
                                                  u"sysop privileges required."
                                                  % redir_page.title())
                             except pywikibot.LockedPage:
-                                pywikibot.output(u'%s is locked.'
-                                                 % redir_page.title())
+                                pywikibot.output(u'{0!s} is locked.'.format(redir_page.title()))
                             except pywikibot.OtherPageSaveError:
                                 pywikibot.exception()
                             else:
@@ -491,8 +484,7 @@ class RedirectRobot(Bot):
                         redir_page.delete(reason, prompt=False)
                     else:
                         assert targetPage.site == self.site, (
-                            u'target page is on different site %s'
-                            % targetPage.site)
+                            u'target page is on different site {0!s}'.format(targetPage.site))
                         if i18n.twhas_key(self.site,
                                           'redirect-broken-redirect-template'):
                             pywikibot.output(u"No sysop in user-config.py, "
@@ -546,60 +538,52 @@ class RedirectRobot(Bot):
         newRedir = redir
         redirList = []  # bookkeeping to detect loops
         while True:
-            redirList.append(u'%s:%s' % (newRedir.site.lang,
+            redirList.append(u'{0!s}:{1!s}'.format(newRedir.site.lang,
                                          newRedir.title(withSection=False)))
             try:
                 targetPage = newRedir.getRedirectTarget()
             except pywikibot.IsNotRedirectPage:
                 if len(redirList) == 1:
-                    pywikibot.output(u'Skipping: Page %s is not a redirect.'
-                                     % redir.title(asLink=True))
+                    pywikibot.output(u'Skipping: Page {0!s} is not a redirect.'.format(redir.title(asLink=True)))
                     break  # do nothing
                 elif len(redirList) == 2:
                     pywikibot.output(
-                        u'Skipping: Redirect target %s is not a redirect.'
-                        % newRedir.title(asLink=True))
+                        u'Skipping: Redirect target {0!s} is not a redirect.'.format(newRedir.title(asLink=True)))
                     break  # do nothing
                 else:
                     pass  # target found
             except pywikibot.SectionError:
                 pywikibot.warning(
-                    u"Redirect target section %s doesn't exist."
-                    % newRedir.title(asLink=True))
+                    u"Redirect target section {0!s} doesn't exist.".format(newRedir.title(asLink=True)))
             except (pywikibot.CircularRedirect,
                     pywikibot.InterwikiRedirectPage) as e:
                 pywikibot.exception(e)
-                pywikibot.output(u"Skipping %s." % newRedir)
+                pywikibot.output(u"Skipping {0!s}.".format(newRedir))
                 break
             except pywikibot.BadTitle as e:
                 # str(e) is in the format 'BadTitle: [[Foo]]'
                 pywikibot.warning(
-                    u'Redirect target %s is not a valid page title.'
-                    % str(e)[10:])
+                    u'Redirect target {0!s} is not a valid page title.'.format(str(e)[10:]))
                 break
             except pywikibot.NoPage:
                 if len(redirList) == 1:
-                    pywikibot.output(u'Skipping: Page %s does not exist.'
-                                     % redir.title(asLink=True))
+                    pywikibot.output(u'Skipping: Page {0!s} does not exist.'.format(redir.title(asLink=True)))
                     break
                 else:
                     if self.getOption('always'):
                         pywikibot.output(
-                            u"Skipping: Redirect target %s doesn't exist."
-                            % newRedir.title(asLink=True))
+                            u"Skipping: Redirect target {0!s} doesn't exist.".format(newRedir.title(asLink=True)))
                         break  # skip if automatic
                     else:
                         pywikibot.warning(
-                            u"Redirect target %s doesn't exist."
-                            % newRedir.title(asLink=True))
+                            u"Redirect target {0!s} doesn't exist.".format(newRedir.title(asLink=True)))
             except pywikibot.ServerError:
                 pywikibot.output(u'Skipping due to server error: '
                                  u'No textarea found')
                 break
             else:
                 pywikibot.output(
-                    u'   Links to: %s.'
-                    % targetPage.title(asLink=True))
+                    u'   Links to: {0!s}.'.format(targetPage.title(asLink=True)))
                 try:
                     mw_msg = targetPage.site.mediawiki_message(
                         'wikieditor-toolbar-tool-redirect-example')
@@ -612,12 +596,10 @@ class RedirectRobot(Bot):
                             u"potentially vandalized.")
                         break
                 # watch out for redirect loops
-                if redirList.count(u'%s:%s'
-                                   % (targetPage.site.lang,
+                if redirList.count(u'{0!s}:{1!s}'.format(targetPage.site.lang,
                                       targetPage.title(withSection=False))):
                     pywikibot.warning(
-                        u'Redirect target %s forms a redirect loop.'
-                        % targetPage.title(asLink=True))
+                        u'Redirect target {0!s} forms a redirect loop.'.format(targetPage.title(asLink=True)))
                     break  # FIXME: doesn't work. edits twice!
                     try:
                         content = targetPage.get(get_redirect=True)
@@ -670,22 +652,18 @@ class RedirectRobot(Bot):
                 try:
                     redir.save(summary)
                 except pywikibot.LockedPage:
-                    pywikibot.output(u'%s is locked.' % redir.title())
+                    pywikibot.output(u'{0!s} is locked.'.format(redir.title()))
                 except pywikibot.SpamfilterError as error:
                     pywikibot.output(
-                        u"Saving page [[%s]] prevented by spam filter: %s"
-                        % (redir.title(), error.url))
+                        u"Saving page [[{0!s}]] prevented by spam filter: {1!s}".format(redir.title(), error.url))
                 except pywikibot.PageNotSaved as error:
-                    pywikibot.output(u"Saving page [[%s]] failed: %s"
-                                     % (redir.title(), error))
+                    pywikibot.output(u"Saving page [[{0!s}]] failed: {1!s}".format(redir.title(), error))
                 except pywikibot.NoUsername:
                     pywikibot.output(
-                        u"Page [[%s]] not saved; sysop privileges required."
-                        % redir.title())
+                        u"Page [[{0!s}]] not saved; sysop privileges required.".format(redir.title()))
                 except pywikibot.Error as error:
                     pywikibot.output(
-                        u"Unexpected error occurred trying to save [[%s]]: %s"
-                        % (redir.title(), error))
+                        u"Unexpected error occurred trying to save [[{0!s}]]: {1!s}".format(redir.title(), error))
             break
 
     def fix_double_or_delete_broken_redirects(self):
@@ -797,7 +775,7 @@ def main(*args):
             issue_deprecation_warning('The usage of "{0}"'.format(arg),
                                       2, ArgumentDeprecationWarning)
         else:
-            pywikibot.output(u'Unknown argument: %s' % arg)
+            pywikibot.output(u'Unknown argument: {0!s}'.format(arg))
 
     if not action or xmlFilename and (moved_pages or fullscan):
         problems = []

--- a/scripts/reflinks.py
+++ b/scripts/reflinks.py
@@ -206,18 +206,18 @@ class RefLink(object):
 
     def refTitle(self):
         """Return the <ref> with its new title."""
-        return '<ref%s>[%s %s<!-- %s -->]</ref>' % (self.refname, self.link,
+        return '<ref{0!s}>[{1!s} {2!s}<!-- {3!s} -->]</ref>'.format(self.refname, self.link,
                                                     self.title,
                                                     self.linkComment)
 
     def refLink(self):
         """No title has been found, return the unbracketed link."""
-        return '<ref%s>%s</ref>' % (self.refname, self.link)
+        return '<ref{0!s}>{1!s}</ref>'.format(self.refname, self.link)
 
     def refDead(self):
         """Dead link, tag it with a {{dead link}}."""
         tag = i18n.translate(self.site, deadLinkTag) % self.link
-        return '<ref%s>%s</ref>' % (self.refname, tag)
+        return '<ref{0!s}>{1!s}</ref>'.format(self.refname, tag)
 
     def transform(self, ispdf=False):
         """Normalize the title."""
@@ -342,7 +342,7 @@ class DuplicateReferences(object):
             id += 1
         for (g, d) in foundRefs.items():
             if g:
-                group = u"group=\"%s\" " % group
+                group = u"group=\"{0!s}\" ".format(group)
             else:
                 group = u""
 
@@ -354,8 +354,8 @@ class DuplicateReferences(object):
                     name = self.autogen + str(id)
                     id += 1
                 elif v[2]:
-                    name = u'"%s"' % name
-                named = u'<ref %sname=%s>%s</ref>' % (group, name, k)
+                    name = u'"{0!s}"'.format(name)
+                named = u'<ref {0!s}name={1!s}>{2!s}</ref>'.format(group, name, k)
                 text = text.replace(v[1][0], named, 1)
 
                 # make sure that the first (named ref) is not
@@ -364,7 +364,7 @@ class DuplicateReferences(object):
                 header = text[:pos]
                 end = text[pos:]
 
-                unnamed = u'<ref %sname=%s />' % (group, name)
+                unnamed = u'<ref {0!s}name={1!s} />'.format(group, name)
                 for ref in v[1][1:]:
                     end = end.replace(ref, unnamed)
                 text = header + end
@@ -373,10 +373,10 @@ class DuplicateReferences(object):
             # TODO : Support ref groups
             name = v[0]
             if v[1]:
-                name = u'"%s"' % name
+                name = u'"{0!s}"'.format(name)
             text = re.sub(
-                u'<ref name\\s*=\\s*(?P<quote>"?)\\s*%s\\s*(?P=quote)\\s*/>' % k,
-                u'<ref name=%s />' % name, text)
+                u'<ref name\\s*=\\s*(?P<quote>"?)\\s*{0!s}\\s*(?P=quote)\\s*/>'.format(k),
+                u'<ref name={0!s} />'.format(name), text)
         return text
 
 
@@ -405,7 +405,7 @@ class ReferencesRobot(Bot):
                 code = alt
                 break
         if code:
-            manual += '/%s' % code
+            manual += '/{0!s}'.format(code)
         if self.getOption('summary') is None:
             self.msg = i18n.twtranslate(self.site, 'reflinks-msg', locals())
         else:
@@ -424,8 +424,7 @@ class ReferencesRobot(Bot):
         try:
             self.stopPageRevId = self.stopPage.latest_revision_id
         except pywikibot.NoPage:
-            pywikibot.output(u'The stop page %s does not exist'
-                             % self.stopPage.title(asLink=True))
+            pywikibot.output(u'The stop page {0!s} does not exist'.format(self.stopPage.title(asLink=True)))
             raise
 
         # Regex to grasp content-type meta HTML tag in HTML source
@@ -469,7 +468,7 @@ class ReferencesRobot(Bot):
                     ref.title = aline.split(None)[1:]
                     ref.title = ' '.join(ref.title)
                     if ref.title != '':
-                        pywikibot.output(u'title: %s' % ref.title)
+                        pywikibot.output(u'title: {0!s}'.format(ref.title))
             pywikibot.output(u'PDF done.')
         except ValueError:
             pywikibot.output(u'pdfinfo value error.')
@@ -500,15 +499,13 @@ class ReferencesRobot(Bot):
                 # Load the page's text from the wiki
                 new_text = page.get()
                 if not page.canBeEdited():
-                    pywikibot.output(u"You can't edit page %s"
-                                     % page.title(asLink=True))
+                    pywikibot.output(u"You can't edit page {0!s}".format(page.title(asLink=True)))
                     continue
             except pywikibot.NoPage:
-                pywikibot.output(u'Page %s not found' % page.title(asLink=True))
+                pywikibot.output(u'Page {0!s} not found'.format(page.title(asLink=True)))
                 continue
             except pywikibot.IsRedirectPage:
-                pywikibot.output(u'Page %s is a redirect'
-                                 % page.title(asLink=True))
+                pywikibot.output(u'Page {0!s} is a redirect'.format(page.title(asLink=True)))
                 continue
 
             # for each link to change
@@ -573,14 +570,13 @@ class ReferencesRobot(Bot):
                             continue
 
                     if f.status_code != requests.codes.ok:
-                        pywikibot.output(u'HTTP error (%s) for %s on %s'
-                                         % (f.status_code, ref.url,
+                        pywikibot.output(u'HTTP error ({0!s}) for {1!s} on {2!s}'.format(f.status_code, ref.url,
                                             page.title(asLink=True)),
                                          toStdout=True)
                         # 410 Gone, indicates that the resource has been purposely
                         # removed
                         if f.status_code == 410 or \
-                           (f.status_code == 404 and (u'\t%s\t' % ref.url in deadLinks)):
+                           (f.status_code == 404 and (u'\t{0!s}\t'.format(ref.url) in deadLinks)):
                             repl = ref.refDead()
                             new_text = new_text.replace(match.group(), repl)
                         continue
@@ -597,8 +593,7 @@ class ReferencesRobot(Bot):
                         socket.error,
                         IOError,
                         httplib.error) as e:
-                    pywikibot.output(u'Can\'t retrieve page %s : %s'
-                                     % (ref.url, e))
+                    pywikibot.output(u'Can\'t retrieve page {0!s} : {1!s}'.format(ref.url, e))
                     continue
 
                 # remove <script>/<style>/comments/CDATA tags
@@ -632,9 +627,9 @@ class ReferencesRobot(Bot):
                     else:
                         enc.append(tmp)
                 else:
-                    pywikibot.output(u'No charset found for %s' % ref.link)
+                    pywikibot.output(u'No charset found for {0!s}'.format(ref.link))
                 if not contentType:
-                    pywikibot.output(u'No content-type found for %s' % ref.link)
+                    pywikibot.output(u'No content-type found for {0!s}'.format(ref.link))
                     continue
                 elif not self.MIME.search(contentType):
                     pywikibot.output(color_format(
@@ -665,7 +660,7 @@ class ReferencesRobot(Bot):
                 try:
                     u = linkedpagetext.decode(enc[0])   # Bug T69410
                 except (UnicodeDecodeError, LookupError) as e:
-                    pywikibot.output(u'%s : Decoding error - %s' % (ref.link, e))
+                    pywikibot.output(u'{0!s} : Decoding error - {1!s}'.format(ref.link, e))
                     continue
 
                 # Retrieves the first non empty string inside <title> tags
@@ -680,14 +675,14 @@ class ReferencesRobot(Bot):
                 if not ref.title:
                     repl = ref.refLink()
                     new_text = new_text.replace(match.group(), repl)
-                    pywikibot.output(u'%s : No title found...' % ref.link)
+                    pywikibot.output(u'{0!s} : No title found...'.format(ref.link))
                     continue
 
                 # XXX Ugly hack
                 if u'Ã©' in ref.title:
                     repl = ref.refLink()
                     new_text = new_text.replace(match.group(), repl)
-                    pywikibot.output(u'%s : Hybrid encoding...' % ref.link)
+                    pywikibot.output(u'{0!s} : Hybrid encoding...'.format(ref.link))
                     continue
 
                 if self.titleBlackList.match(ref.title):
@@ -722,7 +717,7 @@ class ReferencesRobot(Bot):
                 editedpages += 1
 
             if self.getOption('limit') and editedpages >= self.getOption('limit'):
-                pywikibot.output('Edited %s pages, stopping.' % self.getOption('limit'))
+                pywikibot.output('Edited {0!s} pages, stopping.'.format(self.getOption('limit')))
                 return
 
             if editedpages % 20 == 0:
@@ -731,8 +726,7 @@ class ReferencesRobot(Bot):
                 actualRev = self.stopPage.latest_revision_id
                 if actualRev != self.stopPageRevId:
                     pywikibot.output(
-                        u'[[%s]] has been edited : Someone wants us to stop.'
-                        % self.stopPage)
+                        u'[[{0!s}]] has been edited : Someone wants us to stop.'.format(self.stopPage))
                     return
 
 

--- a/scripts/replace.py
+++ b/scripts/replace.py
@@ -440,8 +440,7 @@ class XmlDumpReplacePageGenerator(object):
             try:
                 if not self.skipping:
                     pywikibot.output(
-                        u'To resume, use "-xmlstart:%s" on the command line.'
-                        % entry.title)
+                        u'To resume, use "-xmlstart:{0!s}" on the command line.'.format(entry.title))
             except NameError:
                 pass
 
@@ -685,18 +684,16 @@ class ReplaceRobot(Bot):
         for page in self.generator:
             if self.isTitleExcepted(page.title()):
                 pywikibot.output(
-                    u'Skipping %s because the title is on the exceptions list.'
-                    % page.title(asLink=True))
+                    u'Skipping {0!s} because the title is on the exceptions list.'.format(page.title(asLink=True)))
                 continue
             try:
                 # Load the page's text from the wiki
                 original_text = page.get(get_redirect=True)
                 if not page.canBeEdited():
-                    pywikibot.output(u"You can't edit page %s"
-                                     % page.title(asLink=True))
+                    pywikibot.output(u"You can't edit page {0!s}".format(page.title(asLink=True)))
                     continue
             except pywikibot.NoPage:
-                pywikibot.output(u'Page %s not found' % page.title(asLink=True))
+                pywikibot.output(u'Page {0!s} not found'.format(page.title(asLink=True)))
                 continue
             applied = set()
             new_text = original_text
@@ -714,8 +711,7 @@ class ReplaceRobot(Bot):
                     if not self.recursive:
                         break
                 if new_text == original_text:
-                    pywikibot.output(u'No changes were necessary in %s'
-                                     % page.title(asLink=True))
+                    pywikibot.output(u'No changes were necessary in {0!s}'.format(page.title(asLink=True)))
                     break
                 if hasattr(self, 'addedCat'):
                     # Fetch only categories in wikitext, otherwise the others will
@@ -750,8 +746,7 @@ class ReplaceRobot(Bot):
                     try:
                         original_text = page.get(get_redirect=True, force=True)
                     except pywikibot.NoPage:
-                        pywikibot.output(u'Page %s has been deleted.'
-                                         % page.title())
+                        pywikibot.output(u'Page {0!s} has been deleted.'.format(page.title()))
                         break
                     new_text = original_text
                     continue
@@ -763,8 +758,7 @@ class ReplaceRobot(Bot):
                               callback=self._count_changes, quiet=True)
                 while not self._pending_processed_titles.empty():
                     proc_title, res = self._pending_processed_titles.get()
-                    pywikibot.output('Page %s%s saved'
-                                     % (proc_title, '' if res else ' not'))
+                    pywikibot.output('Page {0!s}{1!s} saved'.format(proc_title, '' if res else ' not'))
                 # choice must be 'N'
                 break
             if self.getOption('always') and new_text != original_text:
@@ -773,23 +767,18 @@ class ReplaceRobot(Bot):
                     page.save(summary=self.generate_summary(applied),
                               callback=self._count_changes, quiet=True)
                 except pywikibot.EditConflict:
-                    pywikibot.output(u'Skipping %s because of edit conflict'
-                                     % (page.title(),))
+                    pywikibot.output(u'Skipping {0!s} because of edit conflict'.format(page.title()))
                 except pywikibot.SpamfilterError as e:
                     pywikibot.output(
-                        u'Cannot change %s because of blacklist entry %s'
-                        % (page.title(), e.url))
+                        u'Cannot change {0!s} because of blacklist entry {1!s}'.format(page.title(), e.url))
                 except pywikibot.LockedPage:
-                    pywikibot.output(u'Skipping %s (locked page)'
-                                     % (page.title(),))
+                    pywikibot.output(u'Skipping {0!s} (locked page)'.format(page.title()))
                 except pywikibot.PageNotSaved as error:
-                    pywikibot.output(u'Error putting page: %s'
-                                     % (error.args,))
+                    pywikibot.output(u'Error putting page: {0!s}'.format(error.args))
                 if self._pending_processed_titles.qsize() > 50:
                     while not self._pending_processed_titles.empty():
                         proc_title, res = self._pending_processed_titles.get()
-                        pywikibot.output('Page %s%s saved'
-                                         % (proc_title, '' if res else ' not'))
+                        pywikibot.output('Page {0!s}{1!s} saved'.format(proc_title, '' if res else ' not'))
 
 
 def prepareRegexForMySQL(pattern):
@@ -986,7 +975,7 @@ def main(*args):
             single_summary = i18n.twtranslate(
                 site, 'replace-replacing',
                 {'description':
-                 ' (-%s +%s)' % (replacement.old, replacement.new)}
+                 ' (-{0!s} +{1!s})'.format(replacement.old, replacement.new)}
             )
         replacements.append(replacement)
 
@@ -996,8 +985,7 @@ def main(*args):
         try:
             fix = fixes.fixes[fix_name]
         except KeyError:
-            pywikibot.output(u'Available predefined fixes are: %s'
-                             % ', '.join(fixes.fixes.keys()))
+            pywikibot.output(u'Available predefined fixes are: {0!s}'.format(', '.join(fixes.fixes.keys())))
             if not fixes.user_fixes_loaded:
                 pywikibot.output('The user fixes file could not be found: '
                                  '{0}'.format(fixes.filename))
@@ -1092,22 +1080,22 @@ def main(*args):
         gen = XmlDumpReplacePageGenerator(xmlFilename, xmlStart,
                                           replacements, exceptions, site)
     elif useSql:
-        whereClause = 'WHERE (%s)' % ' OR '.join(
-            ["old_text RLIKE '%s'" % prepareRegexForMySQL(old_regexp.pattern)
-             for (old_regexp, new_text) in replacements])
+        whereClause = 'WHERE ({0!s})'.format(' OR '.join(
+            ["old_text RLIKE '{0!s}'".format(prepareRegexForMySQL(old_regexp.pattern))
+             for (old_regexp, new_text) in replacements]))
         if exceptions:
-            exceptClause = 'AND NOT (%s)' % ' OR '.join(
-                ["old_text RLIKE '%s'" % prepareRegexForMySQL(exc.pattern)
-                 for exc in exceptions])
+            exceptClause = 'AND NOT ({0!s})'.format(' OR '.join(
+                ["old_text RLIKE '{0!s}'".format(prepareRegexForMySQL(exc.pattern))
+                 for exc in exceptions]))
         else:
             exceptClause = ''
         query = u"""
 SELECT page_namespace, page_title
 FROM page
 JOIN text ON (page_id = old_id)
-%s
-%s
-LIMIT 200""" % (whereClause, exceptClause)
+{0!s}
+{1!s}
+LIMIT 200""".format(whereClause, exceptClause)
         gen = pagegenerators.MySQLPageGenerator(query)
 
     gen = genFactory.getCombinedGenerator(gen)
@@ -1126,7 +1114,7 @@ LIMIT 200""" % (whereClause, exceptClause)
     # Explicitly call pywikibot.stopme().
     # It will make sure the callback is triggered before replace.py is unloaded.
     pywikibot.stopme()
-    pywikibot.output(u'\n%s pages changed.' % bot.changed_pages)
+    pywikibot.output(u'\n{0!s} pages changed.'.format(bot.changed_pages))
 
 
 if __name__ == "__main__":

--- a/scripts/replicate_wiki.py
+++ b/scripts/replicate_wiki.py
@@ -94,7 +94,7 @@ class SyncSites(object):
 
         if options.namespace and 'help' in options.namespace:
             for namespace in self.original.namespaces.values():
-                pywikibot.output('%s %s' % (namespace.id, namespace.custom_name))
+                pywikibot.output('{0!s} {1!s}'.format(namespace.id, namespace.custom_name))
             sys.exit()
 
         self.sites = [pywikibot.Site(s, family) for s in sites]
@@ -138,14 +138,14 @@ class SyncSites(object):
         if self.options.namespace:
             pywikibot.output(str(self.options.namespace))
             namespaces = [int(self.options.namespace)]
-        pywikibot.output("Checking these namespaces: %s\n" % (namespaces,))
+        pywikibot.output("Checking these namespaces: {0!s}\n".format(namespaces))
 
         for ns in namespaces:
             self.check_namespace(ns)
 
     def check_namespace(self, namespace):
         """Check an entire namespace."""
-        pywikibot.output("\nCHECKING NAMESPACE %s" % namespace)
+        pywikibot.output("\nCHECKING NAMESPACE {0!s}".format(namespace))
         pages = (p.title() for p in self.original.allpages(
             '!', namespace=namespace))
         for p in pages:
@@ -165,17 +165,17 @@ class SyncSites(object):
         """Create page on wikis with overview of bot results."""
         for site in self.sites:
             sync_overview_page = Page(site,
-                                      'User:%s/sync.py overview' % site.user())
+                                      'User:{0!s}/sync.py overview'.format(site.user()))
             output = "== Pages that differ from original ==\n\n"
             if self.differences[site]:
-                output += "".join('* [[:%s]]\n' % l for l in
+                output += "".join('* [[:{0!s}]]\n'.format(l) for l in
                                   self.differences[site])
             else:
                 output += "All important pages are the same"
 
             output += "\n\n== Admins from original that are missing here ==\n\n"
             if self.user_diff[site]:
-                output += "".join('* %s\n' % l.replace('_', ' ') for l in
+                output += "".join('* {0!s}\n'.format(l.replace('_', ' ')) for l in
                                   self.user_diff[site])
             else:
                 output += "All users from original are also present on this wiki"
@@ -186,12 +186,11 @@ class SyncSites(object):
 
     def put_message(self, site):
         """Return synchonization message."""
-        return ('%s replicate_wiki.py synchronization from %s'
-                % (site.user(), str(self.original)))
+        return ('{0!s} replicate_wiki.py synchronization from {1!s}'.format(site.user(), str(self.original)))
 
     def check_page(self, pagename):
         """Check one page."""
-        pywikibot.output("\nChecking %s" % pagename)
+        pywikibot.output("\nChecking {0!s}".format(pagename))
         sys.stdout.flush()
         page1 = Page(self.original, pagename)
         txt1 = page1.text
@@ -204,8 +203,7 @@ class SyncSites(object):
         for site in self.sites:
             if dest_ns is not None:
                 page2 = Page(site, page1.title(withNamespace=False), dest_ns)
-                pywikibot.output("\nCross namespace, new title: %s"
-                                 % page2.title())
+                pywikibot.output("\nCross namespace, new title: {0!s}".format(page2.title()))
             else:
                 page2 = Page(site, pagename)
 
@@ -220,11 +218,11 @@ class SyncSites(object):
                 if txt1 != txt_new:
                     pywikibot.output(
                         'NOTE: text replaced using config.sync_replace')
-                    pywikibot.output('%s %s %s' % (txt1, txt_new, txt2))
+                    pywikibot.output('{0!s} {1!s} {2!s}'.format(txt1, txt_new, txt2))
                     txt1 = txt_new
 
             if txt1 != txt2:
-                pywikibot.output("\n %s DIFFERS" % site)
+                pywikibot.output("\n {0!s} DIFFERS".format(site))
                 self.differences[site].append(pagename)
 
         if self.options.replace:

--- a/scripts/revertbot.py
+++ b/scripts/revertbot.py
@@ -85,11 +85,11 @@ class BaseRevertBot(object):
                 if callback(item):
                     result = self.revert(item)
                     if result:
-                        self.log(u'%s: %s' % (item['title'], result))
+                        self.log(u'{0!s}: {1!s}'.format(item['title'], result))
                     else:
-                        self.log(u'Skipped %s' % item['title'])
+                        self.log(u'Skipped {0!s}'.format(item['title']))
                 else:
-                    self.log(u'Skipped %s by callback' % item['title'])
+                    self.log(u'Skipped {0!s} by callback'.format(item['title']))
             except StopIteration:
                 return
 
@@ -134,7 +134,7 @@ class BaseRevertBot(object):
             else:
                 pywikibot.exception()
             return False
-        return u"The edit(s) made in %s by %s was rollbacked" % (page.title(), self.user)
+        return u"The edit(s) made in {0!s} by {1!s} was rollbacked".format(page.title(), self.user)
 
     def log(self, msg):
         """Log the message msg."""

--- a/scripts/script_wui.py
+++ b/scripts/script_wui.py
@@ -174,10 +174,10 @@ class ScriptWUIBot(pywikibot.botirc.IRCBot):
         # test actual page against (template incl.) list
         page = match.group('page').decode(self.site.encoding())
         if page in self.refs:
-            pywikibot.output(u"RELOAD: %s" % page)
+            pywikibot.output(u"RELOAD: {0!s}".format(page))
             self.refs[page].get(force=True)   # re-load (refresh) page content
         if page == self.templ:
-            pywikibot.output(u"SHELL: %s" % page)
+            pywikibot.output(u"SHELL: {0!s}".format(page))
             self.do_check(page)
 
     def on_timer(self):
@@ -203,7 +203,7 @@ class ScriptWUIBot(pywikibot.botirc.IRCBot):
                 now - datetime.timedelta(microseconds=1))
 
             if (delay <= bot_config['CRONMaxDelay']):
-                pywikibot.output(u"CRONTAB: %s / %s / %s" % (page, rev, timestmp))
+                pywikibot.output(u"CRONTAB: {0!s} / {1!s} / {2!s}".format(page, rev, timestmp))
                 self.do_check(page.title(), int(rev))
 
     def do_check(self, page_title, rev=None, params=None):
@@ -268,7 +268,7 @@ def main_script(page, rev=None, params=NotImplemented):  # pylint: disable=unuse
     sys.argv = __sys_argv
 
     pywikibot.output(
-        u'environment: garbage; %s / memory; %s / members; %s' % (
+        u'environment: garbage; {0!s} / memory; {1!s} / members; {2!s}'.format(
             gc.collect(),
             resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * resource.getpagesize(),
             len(dir())))
@@ -293,8 +293,7 @@ def wiki_logger(buffer, page, rev=None):
     outpage = pywikibot.Page(pywikibot.Site(), bot_config['ConfCSSoutput'])
     text = outpage.get()
     outpage.put(
-        text + u"\n== Simulation vom %s mit [%s code:%s] ==\n<pre>\n%s</pre>\n\n"
-        % (pywikibot.Timestamp.now().isoformat(' '), link, rev, buffer))
+        text + u"\n== Simulation vom {0!s} mit [{1!s} code:{2!s}] ==\n<pre>\n{3!s}</pre>\n\n".format(pywikibot.Timestamp.now().isoformat(' '), link, rev, buffer))
 #                comment = pywikibot.translate(self.site.lang, bot_config['msg']))
 
 

--- a/scripts/selflink.py
+++ b/scripts/selflink.py
@@ -68,8 +68,7 @@ class SelflinkBot(MultipleSitesBot, BaseUnlinkBot):
         # https://de.wikipedia.org/w/index.php?diff=next&oldid=35721641
         if '<imagemap>' in self.current_page.text:
             pywikibot.output(
-                u'Skipping page %s because it contains an image map.'
-                % self.current_page.title(asLink=True))
+                u'Skipping page {0!s} because it contains an image map.'.format(self.current_page.title(asLink=True)))
             return
         self.unlink(self.current_page)
 

--- a/scripts/solve_disambiguation.py
+++ b/scripts/solve_disambiguation.py
@@ -360,7 +360,7 @@ def correctcap(link, text):
     """
     linkupper = link.title()
     linklower = first_lower(linkupper)
-    if "[[%s]]" % linklower in text or "[[%s|" % linklower in text:
+    if "[[{0!s}]]".format(linklower) in text or "[[{0!s}|".format(linklower) in text:
         return linklower
     else:
         return linkupper
@@ -389,7 +389,7 @@ class ReferringPageGeneratorWithIgnore(object):
                 namespaces=0 if self.main_only else None
             )
         ]
-        pywikibot.output(u"Found %d references." % len(refs))
+        pywikibot.output(u"Found {0:d} references.".format(len(refs)))
         # Remove ignorables
         if self.disambPage.site.family.name in ignore_title and \
            self.disambPage.site.lang in ignore_title[self.disambPage.site.family.name]:
@@ -397,16 +397,14 @@ class ReferringPageGeneratorWithIgnore(object):
                                    ][self.disambPage.site.lang]:
                 for i in range(len(refs) - 1, -1, -1):
                     if re.match(ig, refs[i].title()):
-                        pywikibot.log(u'Ignoring page %s'
-                                      % refs[i].title())
+                        pywikibot.log(u'Ignoring page {0!s}'.format(refs[i].title()))
                         del refs[i]
                     elif self.primaryIgnoreManager.isIgnored(refs[i]):
                         del refs[i]
         if len(refs) < self.minimum:
-            pywikibot.output(u"Found only %d pages to work on; skipping."
-                             % len(refs))
+            pywikibot.output(u"Found only {0:d} pages to work on; skipping.".format(len(refs)))
             return
-        pywikibot.output(u"Will work on %d pages." % len(refs))
+        pywikibot.output(u"Will work on {0:d} pages.".format(len(refs)))
         for ref in refs:
             yield ref
 
@@ -612,7 +610,7 @@ class DisambiguationRobot(Bot):
         """Show a list of alternatives."""
         list = u'\n'
         for i in range(len(self.alternatives)):
-            list += (u"%3i - %s\n" % (i, self.alternatives[i]))
+            list += (u"{0:3d} - {1!s}\n".format(i, self.alternatives[i]))
         pywikibot.output(list)
 
     def setupRegexes(self):
@@ -639,7 +637,7 @@ class DisambiguationRobot(Bot):
             \[\[  (?P<title>     [^\[\]\|#]*)
                   (?P<section> \#[^\]\|]*)?
                (\|(?P<label>     [^\]]*))?  \]\]
-            (?P<linktrail>%s)''' % linktrail,
+            (?P<linktrail>{0!s})'''.format(linktrail),
                                 flags=re.X)
 
     def treat(self, refPage, disambPage):
@@ -664,28 +662,24 @@ class DisambiguationRobot(Bot):
             text = refPage.get()
             ignoreReason = self.checkContents(text)
             if ignoreReason:
-                pywikibot.output('\n\nSkipping %s because it contains %s.\n\n'
-                                 % (refPage.title(), ignoreReason))
+                pywikibot.output('\n\nSkipping {0!s} because it contains {1!s}.\n\n'.format(refPage.title(), ignoreReason))
             else:
                 include = True
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u'%s is a redirect to %s'
-                             % (refPage.title(), disambPage.title()))
+            pywikibot.output(u'{0!s} is a redirect to {1!s}'.format(refPage.title(), disambPage.title()))
             if disambPage.isRedirectPage():
                 target = self.alternatives[0]
                 if pywikibot.input_yn(u'Do you want to make redirect %s point '
                                       'to %s?' % (refPage.title(), target),
                                       default=False, automatic_quit=False):
-                    redir_text = '#%s [[%s]]' \
-                                 % (self.mysite.redirect(), target)
+                    redir_text = '#{0!s} [[{1!s}]]'.format(self.mysite.redirect(), target)
                     try:
                         refPage.put_async(redir_text, summary=self.comment)
                     except pywikibot.PageNotSaved as error:
-                        pywikibot.output(u'Page not saved: %s' % error.args)
+                        pywikibot.output(u'Page not saved: {0!s}'.format(error.args))
             else:
                 choice = pywikibot.input_choice(
-                    u'Do you want to work on pages linking to %s?'
-                    % refPage.title(),
+                    u'Do you want to work on pages linking to {0!s}?'.format(refPage.title()),
                     [('yes', 'y'), ('no', 'n'), ('change redirect', 'c')], 'n',
                     automatic_quit=False)
                 if choice == 'y':
@@ -702,8 +696,7 @@ class DisambiguationRobot(Bot):
                     include = "redirect"
         except pywikibot.NoPage:
             pywikibot.output(
-                u'Page [[%s]] does not seem to exist?! Skipping.'
-                % refPage.title())
+                u'Page [[{0!s}]] does not seem to exist?! Skipping.'.format(refPage.title()))
             include = False
         if include in (True, "redirect"):
             # make a backup of the original text so we can show the changes later
@@ -717,8 +710,7 @@ class DisambiguationRobot(Bot):
                 m = self.linkR.search(text, pos=curpos)
                 if not m:
                     if n == 0:
-                        pywikibot.output(u"No changes necessary in %s"
-                                         % refPage.title())
+                        pywikibot.output(u"No changes necessary in {0!s}".format(refPage.title()))
                         return True
                     else:
                         # stop loop and save page
@@ -740,8 +732,7 @@ class DisambiguationRobot(Bot):
                         continue
                 except pywikibot.Error:
                     # must be a broken link
-                    pywikibot.log(u"Invalid link [[%s]] in page [[%s]]"
-                                  % (m.group('title'), refPage.title()))
+                    pywikibot.log(u"Invalid link [[{0!s}]] in page [[{1!s}]]".format(m.group('title'), refPage.title()))
                     continue
                 n += 1
                 # how many bytes should be displayed around the current link
@@ -765,7 +756,7 @@ class DisambiguationRobot(Bot):
                            StandardOption('unlink', 'u')]
                 if self.dn_template_str:
                     # '?', '/' for old choice
-                    options += [AliasOption('tag template %s' % self.dn_template_str,
+                    options += [AliasOption('tag template {0!s}'.format(self.dn_template_str),
                                             ['t', '?', '/'])]
                 options += [context_option]
                 if not edited:
@@ -862,12 +853,12 @@ class DisambiguationRobot(Bot):
                     if new_page_title not in new_targets:
                         new_targets.append(new_page_title)
                     if replaceit and trailing_chars:
-                        newlink = "[[%s%s]]%s" % (new_page_title,
+                        newlink = "[[{0!s}{1!s}]]{2!s}".format(new_page_title,
                                                   section,
                                                   trailing_chars)
                     elif replaceit or (new_page_title == link_text and
                                        not section):
-                        newlink = "[[%s]]" % new_page_title
+                        newlink = "[[{0!s}]]".format(new_page_title)
                     # check if we can create a link with trailing characters
                     # instead of a pipelink
                     elif (
@@ -876,12 +867,10 @@ class DisambiguationRobot(Bot):
                         (re.sub(self.trailR, '', link_text[len(new_page_title):]) == '') and
                         (not section)
                     ):
-                        newlink = "[[%s]]%s" \
-                                  % (link_text[:len(new_page_title)],
+                        newlink = "[[{0!s}]]{1!s}".format(link_text[:len(new_page_title)],
                                      link_text[len(new_page_title):])
                     else:
-                        newlink = "[[%s%s|%s]]" \
-                                  % (new_page_title, section, link_text)
+                        newlink = "[[{0!s}{1!s}|{2!s}]]".format(new_page_title, section, link_text)
                     text = text[:m.start()] + newlink + text[m.end():]
                     continue
 
@@ -900,7 +889,7 @@ class DisambiguationRobot(Bot):
                 except pywikibot.LockedPage:
                     pywikibot.output(u'Page not saved: page is locked')
                 except pywikibot.PageNotSaved as error:
-                    pywikibot.output(u'Page not saved: %s' % error.args)
+                    pywikibot.output(u'Page not saved: {0!s}'.format(error.args))
         return True
 
     def findAlternatives(self, disambPage):
@@ -923,8 +912,7 @@ class DisambiguationRobot(Bot):
                     links = disambPage2.linkedPages()
                     links = [correctcap(l, disambPage2.get()) for l in links]
                 except pywikibot.NoPage:
-                    pywikibot.output(u"No page at %s, using redirect target."
-                                     % disambTitle)
+                    pywikibot.output(u"No page at {0!s}, using redirect target.".format(disambTitle))
                     links = disambPage.linkedPages()[:1]
                     links = [correctcap(l, disambPage.get(get_redirect=True))
                              for l in links]
@@ -960,8 +948,7 @@ or press enter to quit:""")
                                  for l in links]
                     except pywikibot.NoPage:
                         pywikibot.output(
-                            'Page does not exist; using first link in page %s.'
-                            % disambPage.title())
+                            'Page does not exist; using first link in page {0!s}.'.format(disambPage.title()))
                         links = disambPage.linkedPages()[:1]
                         links = [correctcap(l, disambPage.get())
                                  for l in links]
@@ -986,7 +973,7 @@ or press enter to quit:""")
             new_targets = []
         # make list of new targets
         comma = self.mysite.mediawiki_message(u"comma-separator")
-        targets = comma.join(u'[[%s]]' % page_title
+        targets = comma.join(u'[[{0!s}]]'.format(page_title)
                              for page_title in new_targets)
 
         if not targets:
@@ -1054,7 +1041,7 @@ or press enter to quit:""")
             if not self.findAlternatives(disambPage):
                 continue
 
-            pywikibot.output('\nAlternatives for %s' % disambPage)
+            pywikibot.output('\nAlternatives for {0!s}'.format(disambPage))
             self.makeAlternativesUnique()
             # sort possible choices
             if config.sort_ignore_case:
@@ -1075,8 +1062,8 @@ or press enter to quit:""")
                     try:
                         self.treat(refPage, disambPage)
                     except QuitKeyboardInterrupt:
-                        pywikibot.output('\nUser quit %s bot run...' %
-                                         self.__class__.__name__)
+                        pywikibot.output('\nUser quit {0!s} bot run...'.format(
+                                         self.__class__.__name__))
                         return
 
             # clear alternatives before working on next disambiguation page

--- a/scripts/spamremove.py
+++ b/scripts/spamremove.py
@@ -134,7 +134,7 @@ def main(*args):
         elif i == 1:
             pywikibot.output('1 pages done.')
         else:
-            pywikibot.output('%d pages done.' % i)
+            pywikibot.output('{0:d} pages done.'.format(i))
 
 
 if __name__ == '__main__':

--- a/scripts/standardize_interwiki.py
+++ b/scripts/standardize_interwiki.py
@@ -64,11 +64,11 @@ comm = pywikibot.translate(site, comment)
 try:
     for pl in site.allpages(start):
         plname = pl.title()
-        pywikibot.output(u'\nLoading %s...' % plname)
+        pywikibot.output(u'\nLoading {0!s}...'.format(plname))
         try:
             oldtext = pl.get()
         except pywikibot.IsRedirectPage:
-            pywikibot.output(u"%s is a redirect!" % plname)
+            pywikibot.output(u"{0!s} is a redirect!".format(plname))
             continue
         old = pl.interwiki()
         new = {}
@@ -82,7 +82,7 @@ try:
                 try:
                     pl.put(newtext, comment=comm)
                 except pywikibot.LockedPage:
-                    pywikibot.output(u"%s is locked" % plname)
+                    pywikibot.output(u"{0!s} is locked".format(plname))
                     continue
             else:
                 pywikibot.output(u'No changes needed.')

--- a/scripts/states_redirect.py
+++ b/scripts/states_redirect.py
@@ -73,7 +73,7 @@ class StatesRedirectBot(pywikibot.Bot):
         if so, create a redirect from Something, ST..
         """
         for sn in self.abbrev:
-            R = re.compile(r', %s$' % sn)
+            R = re.compile(r', {0!s}$'.format(sn))
             if R.search(page.title()):
                 pl = pywikibot.Page(self.site, page.title().replace(sn,
                                     self.abbrev[sn]))
@@ -85,12 +85,10 @@ class StatesRedirectBot(pywikibot.Bot):
                     goal = pl.getRedirectTarget().title()
                     if pywikibot.Page(self.site, goal).exists():
                         pywikibot.output(
-                            u"Not creating %s - redirect already exists."
-                            % goal)
+                            u"Not creating {0!s} - redirect already exists.".format(goal))
                     else:
                         pywikibot.warning(
-                            u"%s already exists but redirects elsewhere!"
-                            % goal)
+                            u"{0!s} already exists but redirects elsewhere!".format(goal))
                 except pywikibot.IsNotRedirectPage:
                     pywikibot.warning(
                         u"Page %s already exists and is not a redirect "
@@ -109,7 +107,7 @@ class StatesRedirectBot(pywikibot.Bot):
                         change = 'y'
                     else:
                         change = pywikibot.input_choice(
-                            u'Create redirect %s?' % pl.title(),
+                            u'Create redirect {0!s}?'.format(pl.title()),
                             (('yes', 'y'), ('no', 'n')))
                     if change == 'y':
                         pl.set_redirect_target(
@@ -139,7 +137,7 @@ def main(*args):
             force = True
         else:
             pywikibot.warning(
-                u'argument "%s" not understood; ignoring.' % arg)
+                u'argument "{0!s}" not understood; ignoring.'.format(arg))
 
     bot = StatesRedirectBot(start, force)
     bot.run()

--- a/scripts/template.py
+++ b/scripts/template.py
@@ -157,14 +157,13 @@ class XmlDumpTemplatePageGenerator(XMLDumpPageGenerator):
         for template in self.templates:
             templatePattern = template.title(withNamespace=False)
             if mysite.namespaces[10].case == 'first-letter':
-                templatePattern = '[%s%s]%s' % (templatePattern[0].upper(),
+                templatePattern = '[{0!s}{1!s}]{2!s}'.format(templatePattern[0].upper(),
                                                 templatePattern[0].lower(),
                                                 templatePattern[1:])
             templatePattern = re.sub(' ', '[_ ]', templatePattern)
             templatePatterns.append(templatePattern)
         templateRegex = re.compile(
-            r'\{\{ *([mM][sS][gG]:)?(?:%s) *(?P<parameters>\|[^}]+|) *}}'
-            % '|'.join(templatePatterns))
+            r'\{{\{{ *([mM][sS][gG]:)?(?:{0!s}) *(?P<parameters>\|[^}}]+|) *}}}}'.format('|'.join(templatePatterns)))
 
         super(XmlDumpTemplatePageGenerator, self).__init__(
             xmlfilename, site=mysite, text_predicate=templateRegex.search)
@@ -228,23 +227,23 @@ class TemplateRobot(ReplaceBot):
 
             if self.getOption('subst') and self.getOption('remove'):
                 replacements.append((templateRegex,
-                                     r'{{subst:%s\g<parameters>}}' % new))
+                                     r'{{{{subst:{0!s}\g<parameters>}}}}'.format(new)))
                 exceptions['inside-tags'] = ['ref', 'gallery']
             elif self.getOption('subst'):
                 replacements.append((templateRegex,
-                                     r'{{subst:%s\g<parameters>}}' % old))
+                                     r'{{{{subst:{0!s}\g<parameters>}}}}'.format(old)))
                 exceptions['inside-tags'] = ['ref', 'gallery']
             elif self.getOption('remove'):
                 replacements.append((templateRegex, ''))
             else:
                 template = pywikibot.Page(self.site, new, ns=10)
                 if not template.exists():
-                    pywikibot.warning(u'Template "%s" does not exist.' % new)
+                    pywikibot.warning(u'Template "{0!s}" does not exist.'.format(new))
                     if not pywikibot.input_yn('Do you want to proceed anyway?',
                                               default=False, automatic_quit=False):
                         continue
                 replacements.append((templateRegex,
-                                     r'{{%s\g<parameters>}}' % new))
+                                     r'{{{{{0!s}\g<parameters>}}}}'.format(new)))
 
         super(TemplateRobot, self).__init__(
             generator, replacements, exceptions,

--- a/scripts/templatecount.py
+++ b/scripts/templatecount.py
@@ -93,14 +93,14 @@ class TemplateCountRobot(object):
         templateDict = cls.template_dict(templates, namespaces)
         pywikibot.stdout('\nList of pages transcluding templates:')
         for key in templates:
-            pywikibot.output(u'* %s' % key)
+            pywikibot.output(u'* {0!s}'.format(key))
         pywikibot.stdout('-' * 36)
         total = 0
         for key in templateDict:
             for page in templateDict[key]:
                 pywikibot.stdout(page.title())
                 total += 1
-        pywikibot.output(u'Total page count: %d' % total)
+        pywikibot.output(u'Total page count: {0:d}'.format(total))
         pywikibot.stdout('Report generated on {0}'
                          ''.format(datetime.datetime.utcnow().isoformat()))
 

--- a/scripts/touch.py
+++ b/scripts/touch.py
@@ -49,14 +49,11 @@ class TouchBot(MultipleSitesBot):
         try:
             page.touch(botflag=self.getOption('botflag'))
         except pywikibot.NoPage:
-            pywikibot.error(u"Page %s does not exist."
-                            % page.title(asLink=True))
+            pywikibot.error(u"Page {0!s} does not exist.".format(page.title(asLink=True)))
         except pywikibot.LockedPage:
-            pywikibot.error(u"Page %s is locked."
-                            % page.title(asLink=True))
+            pywikibot.error(u"Page {0!s} is locked.".format(page.title(asLink=True)))
         except pywikibot.PageNotSaved:
-            pywikibot.error(u"Page %s not saved."
-                            % page.title(asLink=True))
+            pywikibot.error(u"Page {0!s} not saved.".format(page.title(asLink=True)))
 
 
 class PurgeBot(MultipleSitesBot):
@@ -65,8 +62,7 @@ class PurgeBot(MultipleSitesBot):
 
     def treat(self, page):
         """Purge the given page."""
-        pywikibot.output(u'Page %s%s purged'
-                         % (page.title(asLink=True),
+        pywikibot.output(u'Page {0!s}{1!s} purged'.format(page.title(asLink=True),
                             "" if page.purge() else " not"))
 
 

--- a/scripts/transferbot.py
+++ b/scripts/transferbot.py
@@ -127,31 +127,30 @@ def main(*args):
     pywikibot.output(u"""
     Page transfer configuration
     ---------------------------
-    Source: %(fromsite)r
-    Target: %(tosite)r
+    Source: {fromsite!r}
+    Target: {tosite!r}
 
-    Pages to transfer: %(gen_args)s
+    Pages to transfer: {gen_args!s}
 
-    Prefix for transferred pages: %(prefix)s
-    """ % {'fromsite': fromsite, 'tosite': tosite,
-           'gen_args': gen_args, 'prefix': prefix})
+    Prefix for transferred pages: {prefix!s}
+    """.format(**{'fromsite': fromsite, 'tosite': tosite,
+           'gen_args': gen_args, 'prefix': prefix}))
 
     for page in gen:
-        summary = "Moved page from %s" % page.title(asLink=True)
+        summary = "Moved page from {0!s}".format(page.title(asLink=True))
         targetpage = pywikibot.Page(tosite, prefix + page.title())
         edithistpage = pywikibot.Page(tosite, prefix + page.title() + '/edithistory')
 
         if targetpage.exists() and not overwrite:
             pywikibot.output(
-                u"Skipped %s (target page %s exists)" % (
+                u"Skipped {0!s} (target page {1!s} exists)".format(
                     page.title(asLink=True),
                     targetpage.title(asLink=True)
                 )
             )
             continue
 
-        pywikibot.output(u"Moving %s to %s..."
-                         % (page.title(asLink=True),
+        pywikibot.output(u"Moving {0!s} to {1!s}...".format(page.title(asLink=True),
                             targetpage.title(asLink=True)))
 
         pywikibot.log("Getting page text.")

--- a/scripts/unusedfiles.py
+++ b/scripts/unusedfiles.py
@@ -52,22 +52,19 @@ class UnusedFilesBot(Bot):
                                        template_to_the_user)
         self.summary = i18n.twtranslate(self.site, 'unusedfiles-comment')
         if not all([template_image, template_user]):
-            raise pywikibot.Error(u'This script is not localized for %s site.'
-                                  % self.site)
+            raise pywikibot.Error(u'This script is not localized for {0!s} site.'.format(self.site))
         generator = pagegenerators.UnusedFilesGenerator(site=self.site)
         generator = pagegenerators.PreloadingGenerator(generator)
         for image in generator:
             if not image.exists():
-                pywikibot.output("File '%s' does not exist (see bug T71133)."
-                                 % image.title())
+                pywikibot.output("File '{0!s}' does not exist (see bug T71133).".format(image.title()))
                 continue
             # Use fileUrl() and fileIsShared() to confirm it is local media
             # rather than a local page with the same name as shared media.
             if (image.fileUrl() and not image.fileIsShared() and
                     u'http://' not in image.text):
                 if template_image in image.text:
-                    pywikibot.output(u"%s done already"
-                                     % image.title(asLink=True))
+                    pywikibot.output(u"{0!s} done already".format(image.title(asLink=True)))
                     continue
                 self.append_text(image, u"\n\n" + template_image)
                 uploader = image.getFileVersionHistory().pop(0)['user']

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -175,7 +175,7 @@ class UploadRobot(BaseBot):
             file_url = self.url
             pywikibot.warning("file_url is not given. "
                               "Set to self.url by default.")
-        pywikibot.output(u'Reading file %s' % file_url)
+        pywikibot.output(u'Reading file {0!s}'.format(file_url))
         resume = False
         rlen = 0
         _contents = None
@@ -186,7 +186,7 @@ class UploadRobot(BaseBot):
         while not retrieved:
             if resume:
                 pywikibot.output(u"Resume download...")
-                uo.addheader('Range', 'bytes=%s-' % rlen)
+                uo.addheader('Range', 'bytes={0!s}-'.format(rlen))
 
             infile = uo.open(file_url)
 
@@ -212,11 +212,10 @@ class UploadRobot(BaseBot):
                 if rlen < content_len:
                     retrieved = False
                     pywikibot.output(
-                        u"Connection closed at byte %s (%s left)"
-                        % (rlen, content_len))
+                        u"Connection closed at byte {0!s} ({1!s} left)".format(rlen, content_len))
                     if accept_ranges and rlen > 0:
                         resume = True
-                    pywikibot.output(u"Sleeping for %d seconds..." % dt)
+                    pywikibot.output(u"Sleeping for {0:d} seconds...".format(dt))
                     time.sleep(dt)
                     if dt <= 60:
                         dt += 15
@@ -287,8 +286,7 @@ class UploadRobot(BaseBot):
             filename = self.useFilename
         if not self.keepFilename:
             pywikibot.output(
-                u"The filename on the target wiki will default to: %s"
-                % filename)
+                u"The filename on the target wiki will default to: {0!s}".format(filename))
             assert not always
             newfn = pywikibot.input(
                 u'Enter a better name, or press enter to accept:')
@@ -323,7 +321,7 @@ class UploadRobot(BaseBot):
             if invalid:
                 c = "".join(invalid)
                 pywikibot.output(
-                    'Invalid character(s): %s. Please try again' % c)
+                    'Invalid character(s): {0!s}. Please try again'.format(c))
                 continue
             if allowed_formats and ext not in allowed_formats:
                 if always:
@@ -331,8 +329,7 @@ class UploadRobot(BaseBot):
                                      '[{0}]'.format(' '.join(allowed_formats)))
                     continue
                 elif not pywikibot.input_yn(
-                        u"File format is not one of [%s], but %s. Continue?"
-                        % (u' '.join(allowed_formats), ext),
+                        u"File format is not one of [{0!s}], but {1!s}. Continue?".format(u' '.join(allowed_formats), ext),
                         default=False, automatic_quit=False):
                     continue
             potential_file_page = pywikibot.FilePage(self.targetSite, filename)
@@ -371,8 +368,7 @@ class UploadRobot(BaseBot):
 
         # A proper description for the submission.
         # Empty descriptions are not accepted.
-        pywikibot.output(u'The suggested description is:\n%s'
-                         % self.description)
+        pywikibot.output(u'The suggested description is:\n{0!s}'.format(self.description))
 
         # Description must be set and verified
         if not self.description:
@@ -438,7 +434,7 @@ class UploadRobot(BaseBot):
         imagepage = pywikibot.FilePage(site, filename)  # normalizes filename
         imagepage.text = self.description
 
-        pywikibot.output(u'Uploading file to %s via API...' % site)
+        pywikibot.output(u'Uploading file to {0!s} via API...'.format(site))
 
         success = False
         try:
@@ -462,8 +458,7 @@ class UploadRobot(BaseBot):
 
         except pywikibot.data.api.APIError as error:
             if error.code == u'uploaddisabled':
-                pywikibot.error("Upload error: Local file uploads are disabled on %s."
-                                % site)
+                pywikibot.error("Upload error: Local file uploads are disabled on {0!s}.".format(site))
             else:
                 pywikibot.error("Upload error: ", exc_info=True)
             return None
@@ -473,7 +468,7 @@ class UploadRobot(BaseBot):
         else:
             if success:
                 # No warning, upload complete.
-                pywikibot.output(u"Upload of %s successful." % filename)
+                pywikibot.output(u"Upload of {0!s} successful.".format(filename))
                 return filename  # data['filename']
             else:
                 pywikibot.output(u"Upload aborted.")
@@ -484,15 +479,13 @@ class UploadRobot(BaseBot):
         # early check that upload is enabled
         if self.targetSite.is_uploaddisabled():
             pywikibot.error(
-                "Upload error: Local file uploads are disabled on %s."
-                % self.targetSite)
+                "Upload error: Local file uploads are disabled on {0!s}.".format(self.targetSite))
             return
 
         # early check that user has proper rights to upload
         if "upload" not in self.targetSite.userinfo["rights"]:
             pywikibot.error(
-                "User '%s' does not have upload rights on site %s."
-                % (self.targetSite.user(), self.targetSite))
+                "User '{0!s}' does not have upload rights on site {1!s}.".format(self.targetSite.user(), self.targetSite))
             return
         if isinstance(self.url, basestring):
             return self.upload_file(self.url)

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -42,9 +42,9 @@ def check_environ(environ_name):
 
 def main(*args):
     """Print pywikibot version and important settings."""
-    pywikibot.output('Pywikibot: %s' % getversion())
-    pywikibot.output('Release version: %s' % pywikibot.__release__)
-    pywikibot.output('requests version: %s' % requests.__version__)
+    pywikibot.output('Pywikibot: {0!s}'.format(getversion()))
+    pywikibot.output('Release version: {0!s}'.format(pywikibot.__release__))
+    pywikibot.output('requests version: {0!s}'.format(requests.__version__))
 
     has_wikimedia_cert = False
     if (not hasattr(requests, 'certs') or
@@ -52,21 +52,20 @@ def main(*args):
             not callable(requests.certs.where)):
         pywikibot.output('  cacerts: not defined')
     elif not os.path.isfile(requests.certs.where()):
-        pywikibot.output('  cacerts: %s (missing)' % requests.certs.where())
+        pywikibot.output('  cacerts: {0!s} (missing)'.format(requests.certs.where()))
     else:
-        pywikibot.output('  cacerts: %s' % requests.certs.where())
+        pywikibot.output('  cacerts: {0!s}'.format(requests.certs.where()))
 
         with codecs.open(requests.certs.where(), 'r', 'utf-8') as cert_file:
             text = cert_file.read()
             if WMF_CACERT in text:
                 has_wikimedia_cert = True
-        pywikibot.output(u'    certificate test: %s'
-                         % ('ok' if has_wikimedia_cert else 'not ok'))
+        pywikibot.output(u'    certificate test: {0!s}'.format(('ok' if has_wikimedia_cert else 'not ok')))
     if not has_wikimedia_cert:
         pywikibot.output(
             '  Please reinstall requests!')
 
-    pywikibot.output('Python: %s' % sys.version)
+    pywikibot.output('Python: {0!s}'.format(sys.version))
 
     check_environ('PYWIKIBOT2_DIR')
     check_environ('PYWIKIBOT2_DIR_PWB')

--- a/scripts/watchlist.py
+++ b/scripts/watchlist.py
@@ -53,7 +53,7 @@ def isWatched(pageName, site=None):
 
 def refresh(site, sysop=False):
     """Fetch the watchlist."""
-    pywikibot.output(u'Retrieving watchlist for %s via API.' % str(site))
+    pywikibot.output(u'Retrieving watchlist for {0!s} via API.'.format(str(site)))
     return list(site.watched_pages(sysop=sysop, force=True))
 
 
@@ -113,7 +113,7 @@ def main(*args):
     else:
         site = pywikibot.Site()
         watchlist = refresh(site, sysop=sysop)
-        pywikibot.output(u'%i pages in the watchlist.' % len(watchlist))
+        pywikibot.output(u'{0:d} pages in the watchlist.'.format(len(watchlist)))
         for page in watchlist:
             try:
                 pywikibot.stdout(page.title())

--- a/scripts/weblinkchecker.py
+++ b/scripts/weblinkchecker.py
@@ -326,8 +326,7 @@ class LinkChecker(object):
         if not self.serverEncoding:
             try:
                 pywikibot.output(
-                    u'Contacting server %s to find out its default encoding...'
-                    % self.host)
+                    u'Contacting server {0!s} to find out its default encoding...'.format(self.host))
                 conn = self.getConnection()
                 conn.request('HEAD', '/', None, self.header)
                 self.response = conn.getresponse()
@@ -387,10 +386,10 @@ class LinkChecker(object):
         conn = self.getConnection()
         try:
             if useHEAD:
-                conn.request('HEAD', '%s%s' % (self.path, self.query), None,
+                conn.request('HEAD', '{0!s}{1!s}'.format(self.path, self.query), None,
                              self.header)
             else:
-                conn.request('GET', '%s%s' % (self.path, self.query), None,
+                conn.request('GET', '{0!s}{1!s}'.format(self.path, self.query), None,
                              self.header)
             self.response = conn.getresponse()
             # read the server's encoding, in case we need it later
@@ -418,8 +417,7 @@ class LinkChecker(object):
                     self.changeUrl(redirTarget)
                     return True
                 elif redirTarget.startswith('/'):
-                    self.changeUrl(u'%s://%s%s'
-                                   % (self.protocol, self.host, redirTarget))
+                    self.changeUrl(u'{0!s}://{1!s}{2!s}'.format(self.protocol, self.host, redirTarget))
                     return True
                 else:  # redirect to relative position
                     # cut off filename
@@ -433,8 +431,7 @@ class LinkChecker(object):
                             # change /foo/bar/ to /foo/
                             directory = directory[:-1]
                             directory = directory[:directory.rindex('/') + 1]
-                    self.changeUrl('%s://%s%s%s'
-                                   % (self.protocol, self.host, directory,
+                    self.changeUrl('{0!s}://{1!s}{2!s}{3!s}'.format(self.protocol, self.host, directory,
                                       redirTarget))
                     return True
         else:
@@ -449,10 +446,10 @@ class LinkChecker(object):
         try:
             wasRedirected = self.resolveRedirect(useHEAD=useHEAD)
         except UnicodeError as error:
-            return False, u'Encoding Error: %s (%s)' % (
+            return False, u'Encoding Error: {0!s} ({1!s})'.format(
                 error.__class__.__name__, error)
         except httplib.error as error:
-            return False, u'HTTP Error: %s' % error.__class__.__name__
+            return False, u'HTTP Error: {0!s}'.format(error.__class__.__name__)
         except socket.error as error:
             # https://docs.python.org/2/library/socket.html :
             # socket.error :
@@ -471,7 +468,7 @@ class LinkChecker(object):
             # TODO: decode msg. On Linux, it's encoded in UTF-8.
             # How is it encoded in Windows? Or can we somehow just
             # get the English message?
-            return False, u'Socket Error: %s' % repr(msg)
+            return False, u'Socket Error: {0!s}'.format(repr(msg))
         if wasRedirected:
             if self.url in self.redirectChain:
                 if useHEAD:
@@ -485,10 +482,10 @@ class LinkChecker(object):
                         HTTPignore=self.HTTPignore)
                     return redirChecker.check(useHEAD=False)
                 else:
-                    urlList = ['[%s]' % url
+                    urlList = ['[{0!s}]'.format(url)
                                for url in self.redirectChain + [self.url]]
                     return (False,
-                            u'HTTP Redirect Loop: %s' % ' -> '.join(urlList))
+                            u'HTTP Redirect Loop: {0!s}'.format(' -> '.join(urlList)))
             elif len(self.redirectChain) >= 19:
                 if useHEAD:
                     # Some servers don't seem to handle HEAD requests properly,
@@ -501,11 +498,10 @@ class LinkChecker(object):
                         HTTPignore=self.HTTPignore)
                     return redirChecker.check(useHEAD=False)
                 else:
-                    urlList = ['[%s]' % url
+                    urlList = ['[{0!s}]'.format(url)
                                for url in self.redirectChain + [self.url]]
                     return (False,
-                            u'Long Chain of Redirects: %s'
-                            % ' -> '.join(urlList))
+                            u'Long Chain of Redirects: {0!s}'.format(' -> '.join(urlList)))
             else:
                 redirChecker = LinkChecker(self.url, self.redirectChain,
                                            self.serverEncoding,
@@ -515,23 +511,22 @@ class LinkChecker(object):
             try:
                 conn = self.getConnection()
             except httplib.error as error:
-                return False, u'HTTP Error: %s' % error.__class__.__name__
+                return False, u'HTTP Error: {0!s}'.format(error.__class__.__name__)
             try:
-                conn.request('GET', '%s%s'
-                             % (self.path, self.query), None, self.header)
+                conn.request('GET', '{0!s}{1!s}'.format(self.path, self.query), None, self.header)
             except socket.error as error:
-                return False, u'Socket Error: %s' % repr(error[1])
+                return False, u'Socket Error: {0!s}'.format(repr(error[1]))
             try:
                 self.response = conn.getresponse()
             except Exception as error:
-                return False, u'Error: %s' % error
+                return False, u'Error: {0!s}'.format(error)
             # read the server's encoding, in case we need it later
             self.readEncodingFromResponse(self.response)
             # site down if the server status is between 400 and 499
             alive = self.response.status not in range(400, 500)
             if self.response.status in self.HTTPignore:
                 alive = False
-            return alive, '%s %s' % (self.response.status, self.response.reason)
+            return alive, '{0!s} {1!s}'.format(self.response.status, self.response.reason)
 
 
 class LinkCheckThread(threading.Thread):
@@ -558,7 +553,7 @@ class LinkCheckThread(threading.Thread):
             'Connection': 'keep-alive',
         }
         # identification for debugging purposes
-        self.setName((u'%s - %s' % (page.title(), url)).encode('utf-8',
+        self.setName((u'{0!s} - {1!s}'.format(page.title(), url)).encode('utf-8',
                                                                'replace'))
         self.HTTPignore = HTTPignore
         self.day = day
@@ -575,8 +570,7 @@ class LinkCheckThread(threading.Thread):
                                        'weblinkchecker-badurl_msg',
                                        {'URL': self.url})
         except:
-            pywikibot.output('Exception while processing URL %s in page %s'
-                             % (self.url, self.page.title()))
+            pywikibot.output('Exception while processing URL {0!s} in page {1!s}'.format(self.url, self.page.title()))
             raise
         if (r.status_code == requests.codes.ok and
                 str(r.status_code) not in self.HTTPignore):
@@ -585,11 +579,9 @@ class LinkCheckThread(threading.Thread):
             message = '{0} {1}'.format(r.status_code, r.reason)
         if ok:
             if self.history.setLinkAlive(self.url):
-                pywikibot.output('*Link to %s in [[%s]] is back alive.'
-                                 % (self.url, self.page.title()))
+                pywikibot.output('*Link to {0!s} in [[{1!s}]] is back alive.'.format(self.url, self.page.title()))
         else:
-            pywikibot.output('*[[%s]] links to %s - %s.'
-                             % (self.page.title(), self.url, message))
+            pywikibot.output('*[[{0!s}]] links to {1!s} - {2!s}.'.format(self.page.title(), self.url, message))
             self.history.setLinkDead(self.url, message, self.page,
                                      config.weblink_dead_days)
 
@@ -627,7 +619,7 @@ class History(object):
             self.site = site
         self.semaphore = threading.Semaphore()
         self.datfilename = pywikibot.config.datafilepath(
-            'deadlinks', 'deadlinks-%s-%s.dat' % (self.site.family.name, self.site.code))
+            'deadlinks', 'deadlinks-{0!s}-{1!s}.dat'.format(self.site.family.name, self.site.code))
         # Count the number of logged links, so that we can insert captions
         # from time to time
         self.logCount = 0
@@ -641,24 +633,23 @@ class History(object):
     def log(self, url, error, containingPage, archiveURL):
         """Log an error report to a text file in the deadlinks subdirectory."""
         if archiveURL:
-            errorReport = u'* %s ([%s archive])\n' % (url, archiveURL)
+            errorReport = u'* {0!s} ([{1!s} archive])\n'.format(url, archiveURL)
         else:
-            errorReport = u'* %s\n' % url
+            errorReport = u'* {0!s}\n'.format(url)
         for (pageTitle, date, error) in self.historyDict[url]:
             # ISO 8601 formulation
             isoDate = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(date))
-            errorReport += "** In [[%s]] on %s, %s\n" % (pageTitle, isoDate,
+            errorReport += "** In [[{0!s}]] on {1!s}, {2!s}\n".format(pageTitle, isoDate,
                                                          error)
         pywikibot.output(u"** Logging link for deletion.")
         txtfilename = pywikibot.config.datafilepath('deadlinks',
-                                                    'results-%s-%s.txt'
-                                                    % (self.site.family.name,
+                                                    'results-{0!s}-{1!s}.txt'.format(self.site.family.name,
                                                        self.site.lang))
         txtfile = codecs.open(txtfilename, 'a', 'utf-8')
         self.logCount += 1
         if self.logCount % 30 == 0:
             # insert a caption
-            txtfile.write('=== %s ===\n' % containingPage.title()[:3])
+            txtfile.write('=== {0!s} ===\n'.format(containingPage.title()[:3]))
         txtfile.write(errorReport)
         txtfile.close()
 
@@ -799,19 +790,17 @@ class DeadLinkReportThread(threading.Thread):
                 i = 1
                 count = u''
                 # Check if there is already such a caption on the talk page.
-                while re.search('= *%s%s *=' % (caption, count),
+                while re.search('= *{0!s}{1!s} *='.format(caption, count),
                                 content) is not None:
                     i += 1
                     count = u' ' + str(i)
                 caption += count
-                content += '\n\n== %s ==\n\n%s\n\n%s%s--~~~~' % \
-                           (caption,
+                content += '\n\n== {0!s} ==\n\n{1!s}\n\n{2!s}{3!s}--~~~~'.format(caption,
                             i18n.twtranslate(containingPage.site,
                                              'weblinkchecker-report'),
                             errorReport,
                             archiveMsg)
-                comment = u'[[%s#%s|→]] %s' % \
-                          (talkPage.title(), caption,
+                comment = u'[[{0!s}#{1!s}|→]] {2!s}'.format(talkPage.title(), caption,
                            i18n.twtranslate(containingPage.site,
                                             'weblinkchecker-summary'))
                 try:
@@ -922,7 +911,7 @@ def main(*args):
     HTTPignore = []
 
     if isinstance(memento_client, ImportError):
-        warn('memento_client not imported: %s' % memento_client, ImportWarning)
+        warn('memento_client not imported: {0!s}'.format(memento_client), ImportWarning)
 
     # Process global args and prepare generator args parser
     local_args = pywikibot.handle_args(args)
@@ -986,8 +975,7 @@ def main(*args):
                     pywikibot.output(u'Interrupted.')
                     break
             if countLinkCheckThreads() > 0:
-                pywikibot.output(u'Remaining %i threads will be killed.'
-                                 % countLinkCheckThreads())
+                pywikibot.output(u'Remaining {0:d} threads will be killed.'.format(countLinkCheckThreads()))
                 # Threads will die automatically because they are daemonic.
             if bot.history.reportThread:
                 bot.history.reportThread.shutdown()

--- a/scripts/welcome.py
+++ b/scripts/welcome.py
@@ -456,15 +456,13 @@ class WelcomeBot(object):
             site_netext = netext[self.site.family.name]
         except KeyError:
             raise KeyError(
-                u'Site %s not managed by welcome.py: family "%s" missing in netext.'
-                % (self.site, self.site.family.name))
+                u'Site {0!s} not managed by welcome.py: family "{1!s}" missing in netext.'.format(self.site, self.site.family.name))
         # Raises KeyError if site is not in netext with language.
         try:
             site_netext = site_netext[self.site.code]
         except KeyError:
             raise KeyError(
-                u'Site %s not managed by welcome.py: lang "%s" missing in netext[%s].'
-                % (self.site, self.site.code, self.site.family.name))
+                u'Site {0!s} not managed by welcome.py: lang "{1!s}" missing in netext[{2!s}].'.format(self.site, self.site.code, self.site.family.name))
 
     def badNameFilter(self, name, force=False):
         """Check for bad names."""
@@ -513,8 +511,7 @@ class WelcomeBot(object):
                                                          bad_pag))
             list_loaded = list()
             if badword_page.exists():
-                pywikibot.output(u'\nLoading the bad words list from %s...'
-                                 % self.site)
+                pywikibot.output(u'\nLoading the bad words list from {0!s}...'.format(self.site))
                 list_loaded = load_word_function(badword_page.get())
             else:
                 showStatus(4)
@@ -530,8 +527,7 @@ class WelcomeBot(object):
             if wtlpg:
                 whitelist_page = pywikibot.Page(self.site, wtlpg)
                 if whitelist_page.exists():
-                    pywikibot.output(u'\nLoading the whitelist from %s...'
-                                     % self.site)
+                    pywikibot.output(u'\nLoading the whitelist from {0!s}...'.format(self.site))
                     list_white = load_word_function(whitelist_page.get())
                 else:
                     showStatus(4)
@@ -581,8 +577,7 @@ class WelcomeBot(object):
             if answer.lower() in ['yes', 'y'] or not globalvar.confirm:
                 showStatus()
                 pywikibot.output(
-                    u'%s is possibly an unwanted username. It will be reported.'
-                    % name)
+                    u'{0!s} is possibly an unwanted username. It will be reported.'.format(name))
                 if hasattr(self, '_BAQueue'):
                     self._BAQueue.append(name)
                 else:
@@ -607,14 +602,13 @@ class WelcomeBot(object):
                 n = re.compile(re.escape(username), re.UNICODE)
                 y = n.search(text_get, pos)
                 if y:
-                    pywikibot.output(u'%s is already in the report page.'
-                                     % username)
+                    pywikibot.output(u'{0!s} is already in the report page.'.format(username))
                 else:
                     # Adding the log.
                     rep_text += i18n.translate(self.site,
                                                report_text) % username
                     if self.site.code == 'it':
-                        rep_text = "%s%s}}" % (rep_text, self.bname[username])
+                        rep_text = "{0!s}{1!s}}}}}".format(rep_text, self.bname[username])
 
             com = i18n.twtranslate(self.site, 'welcome-bad_username')
             if rep_text != '':
@@ -654,14 +648,14 @@ class WelcomeBot(object):
                 'Log page is not exist, getting information for page creation')
             text = i18n.translate(self.site, logpage_header,
                                   fallback=i18n.DEFAULT_FALLBACK)
-            text += u'\n!%s' % self.site.namespace(2)
-            text += u'\n!%s' % str.capitalize(
-                self.site.mediawiki_message('contribslink'))
+            text += u'\n!{0!s}'.format(self.site.namespace(2))
+            text += u'\n!{0!s}'.format(str.capitalize(
+                self.site.mediawiki_message('contribslink')))
 
         for result in queue:
             # Adding the log... (don't take care of the variable's name...).
             luser = pywikibot.url2link(result.name(), self.site, self.site)
-            text += u'\n{{WLE|user=%s|contribs=%d}}' % (
+            text += u'\n{{{{WLE|user={0!s}|contribs={1:d}}}}}'.format(
                 luser, result.editCount())
         # update log page.
         while True:
@@ -690,8 +684,7 @@ class WelcomeBot(object):
             if not signPageName:
                 showStatus(4)
                 pywikibot.output(
-                    "%s doesn't allow random signature, force disable."
-                    % self.site)
+                    "{0!s} doesn't allow random signature, force disable.".format(self.site))
                 globalvar.randomSign = False
                 return
 
@@ -729,26 +722,23 @@ class WelcomeBot(object):
             for users in us:
                 if users.isBlocked():
                     showStatus(3)
-                    pywikibot.output(u'%s has been blocked!' % users.name())
+                    pywikibot.output(u'{0!s} has been blocked!'.format(users.name()))
                     continue
                 if 'bot' in users.groups():
                     showStatus(3)
-                    pywikibot.output(u'%s is a bot!' % users.name())
+                    pywikibot.output(u'{0!s} is a bot!'.format(users.name()))
                     continue
                 if 'bot' in users.name().lower():
                     showStatus(3)
-                    pywikibot.output(u'%s might be a global bot!'
-                                     % users.name())
+                    pywikibot.output(u'{0!s} might be a global bot!'.format(users.name()))
                     continue
                 if users.editCount() >= globalvar.attachEditCount:
                     showStatus(2)
-                    pywikibot.output(u'%s has enough edits to be welcomed.'
-                                     % users.name())
+                    pywikibot.output(u'{0!s} has enough edits to be welcomed.'.format(users.name()))
                     ustp = users.getUserTalkPage()
                     if ustp.exists():
                         showStatus(3)
-                        pywikibot.output(u'%s has been already welcomed.'
-                                         % users.name())
+                        pywikibot.output(u'{0!s} has been already welcomed.'.format(users.name()))
                         continue
                     else:
                         if self.badNameFilter(users.name()):
@@ -793,8 +783,7 @@ class WelcomeBot(object):
                         elif welcomed_count == 0:
                             pywikibot.output(u'No users have been welcomed.')
                         else:
-                            pywikibot.output(u'%s users have been welcomed.'
-                                             % welcomed_count)
+                            pywikibot.output(u'{0!s} users have been welcomed.'.format(welcomed_count))
                         if welcomed_count >= globalvar.dumpToLog:
                             if self.makelogpage(self.welcomed_users):
                                 self.welcomed_users = list()
@@ -806,12 +795,10 @@ class WelcomeBot(object):
                     if users.editCount() == 0:
                         if not globalvar.quiet:
                             showStatus(1)
-                            pywikibot.output(u'%s has no contributions.'
-                                             % users.name())
+                            pywikibot.output(u'{0!s} has no contributions.'.format(users.name()))
                     else:
                         showStatus(1)
-                        pywikibot.output(u'%s has only %d contributions.'
-                                         % (users.name(), users.editCount()))
+                        pywikibot.output(u'{0!s} has only {1:d} contributions.'.format(users.name(), users.editCount()))
                     # That user mustn't be welcomed.
                     continue
             if globalvar.makeWelcomeLog and i18n.translate(
@@ -821,8 +808,7 @@ class WelcomeBot(object):
                     pywikibot.output(u'Putting the log of the latest user...')
                 else:
                     pywikibot.output(
-                        u'Putting the log of the latest %d users...'
-                        % welcomed_count)
+                        u'Putting the log of the latest {0:d} users...'.format(welcomed_count))
                 if self.makelogpage(self.welcomed_users):
                     self.welcomed_users = list()
                 else:
@@ -843,8 +829,7 @@ class WelcomeBot(object):
                     else:
                         strfstr = time.strftime(
                             u"%d %b %Y %H:%M:%S (UTC)", time.gmtime())
-                    pywikibot.output(u'Sleeping %d seconds before rerun. %s'
-                                     % (globalvar.timeRecur, strfstr))
+                    pywikibot.output(u'Sleeping {0:d} seconds before rerun. {1!s}'.format(globalvar.timeRecur, strfstr))
                     pywikibot.stopme()
                     time.sleep(globalvar.timeRecur)
                 else:
@@ -974,8 +959,7 @@ def main(*args):
 
     # Filename and Pywikibot path
     # file where is stored the random signature index
-    filename = pywikibot.config.datafilepath('welcome-%s-%s.data'
-                                             % (pywikibot.Site().family.name,
+    filename = pywikibot.config.datafilepath('welcome-{0!s}-{1!s}.data'.format(pywikibot.Site().family.name,
                                                 pywikibot.Site().code))
     if globalvar.offset and globalvar.timeoffset:
         pywikibot.warning(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -60,7 +60,7 @@ def create_path_func(base_func, subpath):
 join_root_path.path = 'root'
 join_tests_path = create_path_func(join_root_path, 'tests')
 join_cache_path = create_path_func(join_tests_path,
-                                   'apicache-py%d' % PYTHON_VERSION[0])
+                                   'apicache-py{0:d}'.format(PYTHON_VERSION[0]))
 join_data_path = create_path_func(join_tests_path, 'data')
 join_pages_path = create_path_func(join_tests_path, 'pages')
 
@@ -203,16 +203,13 @@ def collector(loader=unittest.loader.defaultTestLoader):
     # cause the loader to fallback to its own
     # discover() ordering of unit tests.
     if disabled_test_modules:
-        print('Disabled test modules (to run: python -m unittest ...):\n  %s'
-              % ', '.join(disabled_test_modules))
+        print('Disabled test modules (to run: python -m unittest ...):\n  {0!s}'.format(', '.join(disabled_test_modules)))
 
     if extra_test_modules:
-        print('Extra test modules (run after library, before scripts):\n  %s'
-              % ', '.join(extra_test_modules))
+        print('Extra test modules (run after library, before scripts):\n  {0!s}'.format(', '.join(extra_test_modules)))
 
     if disabled_tests:
-        print('Skipping tests (to run: python -m unittest ...):\n  %r'
-              % disabled_tests)
+        print('Skipping tests (to run: python -m unittest ...):\n  {0!r}'.format(disabled_tests))
 
     modules = [module
                for module in test_modules
@@ -261,7 +258,7 @@ CachedRequest._get_cache_dir = classmethod(
 # frequently in code paths resulting from mishandled server problems.
 if config.max_retries > 2:
     if 'PYWIKIBOT_TEST_QUIET' not in os.environ:
-        print('tests: max_retries reduced from %d to 1' % config.max_retries)
+        print('tests: max_retries reduced from {0:d} to 1'.format(config.max_retries))
     config.max_retries = 1
 
 cache_misses = 0

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -429,8 +429,7 @@ class TestParamInfo(DefaultSiteTestCase):
         site = self.get_site()
         if MediaWikiVersion(site.version()) < MediaWikiVersion('1.25wmf4'):
             raise unittest.SkipTest(
-                "version %s doesn't support the new paraminfo api"
-                % site.version())
+                "version {0!s} doesn't support the new paraminfo api".format(site.version()))
         pi = api.ParamInfo(site, modules_only_mode=True)
         pi.fetch(['info'])
         self.assertIn('query+info', pi._paraminfo)

--- a/tests/archivebot_tests.py
+++ b/tests/archivebot_tests.py
@@ -58,8 +58,7 @@ class TestArchiveBot(TestCase):
         self.assertIsInstance(talk.threads, list)
         self.assertGreaterEqual(
             len(talk.threads), THREADS[code],
-            u'%d Threads found on %s,\n%d or more expected'
-            % (len(talk.threads), talk, THREADS[code]))
+            u'{0:d} Threads found on {1!s},\n{2:d} or more expected'.format(len(talk.threads), talk, THREADS[code]))
 
         for thread in talk.threads:
             self.assertIsInstance(thread, archivebot.DiscussionThread)
@@ -75,7 +74,7 @@ class TestArchiveBot(TestCase):
                 self.assertIsInstance(thread.timestamp, datetime)
             except AssertionError:
                 if thread.code not in self.expected_failures:
-                    pywikibot.output('code %s: %s' % (thread.code, thread.content))
+                    pywikibot.output('code {0!s}: {1!s}'.format(thread.code, thread.content))
                 raise
 
     expected_failures = ['ar', 'pdc', 'th']

--- a/tests/aspects.py
+++ b/tests/aspects.py
@@ -135,7 +135,7 @@ class TestCaseBase(unittest.TestCase):
             namespaces = set([namespaces])
 
         self.assertIn(page.namespace(), namespaces,
-                      "%s not in namespace %r" % (page, namespaces))
+                      "{0!s} not in namespace {1!r}".format(page, namespaces))
 
     def _get_gen_pages(self, gen, count=None, site=None):
         """
@@ -223,8 +223,7 @@ class TestCaseBase(unittest.TestCase):
         page_namespaces = [page.namespace() for page in gen]
 
         if skip and set(page_namespaces) != namespaces:
-            raise unittest.SkipTest('Pages in namespaces %r not found.'
-                                    % list(namespaces - set(page_namespaces)))
+            raise unittest.SkipTest('Pages in namespaces {0!r} not found.'.format(list(namespaces - set(page_namespaces))))
         else:
             self.assertEqual(set(page_namespaces), namespaces)
 
@@ -311,7 +310,7 @@ class TestTimerMixin(TestCaseBase):
         duration = self.test_completed - self.test_start
 
         if duration > self.test_duration_warning_interval:
-            print(' %0.3fs' % duration, end=' ')
+            print(' {0:0.3f}s'.format(duration), end=' ')
             sys.stdout.flush()
 
         super(TestTimerMixin, self).tearDown()
@@ -359,8 +358,7 @@ class DisableSiteMixin(TestCaseBase):
     def setUp(self):
         """Set up test."""
         self.old_Site_lookup_method = pywikibot.Site
-        pywikibot.Site = lambda *args: self.fail('%s: Site() not permitted'
-                                                 % self.__class__.__name__)
+        pywikibot.Site = lambda *args: self.fail('{0!s}: Site() not permitted'.format(self.__class__.__name__))
 
         super(DisableSiteMixin, self).setUp()
 
@@ -399,8 +397,7 @@ class SiteNotPermitted(pywikibot.site.BaseSite):
     def __init__(self, code, fam=None, user=None, sysop=None):
         """Constructor."""
         raise pywikibot.SiteDefinitionError(
-            'Loading site %s:%s during dry test not permitted'
-            % (fam, code))
+            'Loading site {0!s}:{1!s} during dry test not permitted'.format(fam, code))
 
 
 class DisconnectedSiteMixin(TestCaseBase):
@@ -455,9 +452,9 @@ class CacheInfoMixin(TestCaseBase):
         self.cache_hits = tests.cache_hits - self.cache_hits_start
 
         if self.cache_misses:
-            print(' %d cache misses' % self.cache_misses, end=' ')
+            print(' {0:d} cache misses'.format(self.cache_misses), end=' ')
         if self.cache_hits:
-            print(' %d cache hits' % self.cache_hits, end=' ')
+            print(' {0:d} cache hits'.format(self.cache_hits), end=' ')
 
         if self.cache_misses or self.cache_hits:
             sys.stdout.flush()
@@ -485,19 +482,16 @@ class CheckHostnameMixin(TestCaseBase):
 
         for key, data in cls.sites.items():
             if 'hostname' not in data:
-                raise Exception('%s: hostname not defined for %s'
-                                % (cls.__name__, key))
+                raise Exception('{0!s}: hostname not defined for {1!s}'.format(cls.__name__, key))
             hostname = data['hostname']
 
             if hostname in cls._checked_hostnames:
                 if isinstance(cls._checked_hostnames[hostname], Exception):
                     raise unittest.SkipTest(
-                        '%s: hostname %s failed (cached): %s'
-                        % (cls.__name__, hostname,
+                        '{0!s}: hostname {1!s} failed (cached): {2!s}'.format(cls.__name__, hostname,
                            cls._checked_hostnames[hostname]))
                 elif cls._checked_hostnames[hostname] is False:
-                    raise unittest.SkipTest('%s: hostname %s failed (cached)'
-                                            % (cls.__name__, hostname))
+                    raise unittest.SkipTest('{0!s}: hostname {1!s} failed (cached)'.format(cls.__name__, hostname))
                 else:
                     continue
 
@@ -512,10 +506,9 @@ class CheckHostnameMixin(TestCaseBase):
                     e = r.exception
                 else:
                     if r.status not in [200, 301, 302, 303, 307, 308]:
-                        raise ServerError('HTTP status: %d' % r.status)
+                        raise ServerError('HTTP status: {0:d}'.format(r.status))
             except Exception as e2:
-                pywikibot.error('%s: accessing %s caused exception:'
-                                % (cls.__name__, hostname))
+                pywikibot.error('{0!s}: accessing {1!s} caused exception:'.format(cls.__name__, hostname))
                 pywikibot.exception(e2, tb=True)
                 e = e2
                 pass
@@ -523,8 +516,7 @@ class CheckHostnameMixin(TestCaseBase):
             if e:
                 cls._checked_hostnames[hostname] = e
                 raise unittest.SkipTest(
-                    '%s: hostname %s failed: %s'
-                    % (cls.__name__, hostname, e))
+                    '{0!s}: hostname {1!s} failed: {2!s}'.format(cls.__name__, hostname, e))
 
             cls._checked_hostnames[hostname] = True
 
@@ -594,8 +586,7 @@ class RequireUserMixin(TestCaseBase):
         """Check the user config has a valid login to the site."""
         if not cls.has_site_user(family, code, sysop=sysop):
             raise unittest.SkipTest(
-                '%s: No %susername for %s:%s'
-                % (cls.__name__,
+                '{0!s}: No {1!s}username for {2!s}:{3!s}'.format(cls.__name__,
                    "sysop " if sysop else "",
                    family, code))
 
@@ -624,8 +615,7 @@ class RequireUserMixin(TestCaseBase):
 
             if not site['site'].user():
                 raise unittest.SkipTest(
-                    '%s: Not able to login to %s as %s'
-                    % (cls.__name__,
+                    '{0!s}: Not able to login to {1!s} as {2!s}'.format(cls.__name__,
                        'sysop' if sysop else 'bot',
                        site['site']))
 
@@ -799,8 +789,7 @@ class MetaTestCaseClass(type):
             # If there isn't a site, require declaration of net activity.
             if 'net' not in dct:
                 raise Exception(
-                    '%s: Test classes without a site configured must set "net"'
-                    % name)
+                    '{0!s}: Test classes without a site configured must set "net"'.format(name))
 
             # If the 'net' attribute is a false value,
             # remove it so it matches !net in nose.
@@ -928,8 +917,7 @@ class TestCase(TestTimerMixin, TestCaseBase):
             if ('code' in data and data['code'] in ('test', 'mediawiki') and
                     'PYWIKIBOT2_TEST_PROD_ONLY' in os.environ and not dry):
                 raise unittest.SkipTest(
-                    'Site code "%s" and PYWIKIBOT2_TEST_PROD_ONLY is set.'
-                    % data['code'])
+                    'Site code "{0!s}" and PYWIKIBOT2_TEST_PROD_ONLY is set.'.format(data['code']))
 
             if 'site' not in data and 'code' in data and 'family' in data:
                 data['site'] = Site(data['code'], data['family'],
@@ -967,12 +955,10 @@ class TestCase(TestTimerMixin, TestCaseBase):
                 name = next(iter(cls.sites.keys()))
             else:
                 raise Exception(
-                    '"%s.get_site(name=None)" called with multiple sites'
-                    % cls.__name__)
+                    '"{0!s}.get_site(name=None)" called with multiple sites'.format(cls.__name__))
 
         if name and name not in cls.sites:
-            raise Exception('"%s" not declared in %s'
-                            % (name, cls.__name__))
+            raise Exception('"{0!s}" not declared in {1!s}'.format(name, cls.__name__))
 
         if isinstance(cls.site, BaseSite):
             assert cls.sites[name]['site'] == cls.site
@@ -984,9 +970,9 @@ class TestCase(TestTimerMixin, TestCaseBase):
     def has_site_user(cls, family, code, sysop=False):
         """Check the user config has a user for the site."""
         if not family:
-            raise Exception('no family defined for %s' % cls.__name__)
+            raise Exception('no family defined for {0!s}'.format(cls.__name__))
         if not code:
-            raise Exception('no site code defined for %s' % cls.__name__)
+            raise Exception('no site code defined for {0!s}'.format(cls.__name__))
 
         usernames = config.sysopnames if sysop else config.usernames
 
@@ -1177,8 +1163,7 @@ class DefaultSiteTestCase(TestCase):
         @param site: site tests should use
         @type site: BaseSite
         """
-        print('%s using %s instead of %s:%s.'
-              % (cls.__name__, site, cls.family, cls.code))
+        print('{0!s} using {1!s} instead of {2!s}:{3!s}.'.format(cls.__name__, site, cls.family, cls.code))
         cls.site = site
         cls.family = site.family.name
         cls.code = site.code
@@ -1285,14 +1270,12 @@ class WikibaseTestCase(TestCase):
                 site = data['site']
                 if not site.has_data_repository:
                     raise unittest.SkipTest(
-                        u'%s: %r does not have data repository'
-                        % (cls.__name__, site))
+                        u'{0!s}: {1!r} does not have data repository'.format(cls.__name__, site))
 
                 if (hasattr(cls, 'repo') and
                         cls.repo != site.data_repository()):
                     raise Exception(
-                        '%s: sites do not all have the same data repository'
-                        % cls.__name__)
+                        '{0!s}: sites do not all have the same data repository'.format(cls.__name__))
 
                 cls.repo = site.data_repository()
 
@@ -1329,8 +1312,7 @@ class WikibaseClientTestCase(WikibaseTestCase):
         for site in cls.sites.values():
             if not site['site'].has_transcluded_data:
                 raise unittest.SkipTest(
-                    u'%s: %r does not have transcluded data'
-                    % (cls.__name__, site['site']))
+                    u'{0!s}: {1!r} does not have transcluded data'.format(cls.__name__, site['site']))
 
 
 class DefaultWikibaseClientTestCase(WikibaseClientTestCase,
@@ -1366,8 +1348,7 @@ class DefaultWikidataClientTestCase(DefaultWikibaseClientTestCase):
 
         if str(cls.get_repo()) != 'wikidata:wikidata':
             raise unittest.SkipTest(
-                u'%s: %s is not connected to Wikidata.'
-                % (cls.__name__, cls.get_site()))
+                u'{0!s}: {1!s} is not connected to Wikidata.'.format(cls.__name__, cls.get_site()))
 
 
 class ScriptMainTestCase(ScenarioDefinedDefaultSiteTestCase):
@@ -1454,7 +1435,7 @@ class DebugOnlyTestCase(TestCase):
         """Set up test class."""
         if not __debug__:
             raise unittest.SkipTest(
-                '%s is disabled when __debug__ is disabled.' % cls.__name__)
+                '{0!s} is disabled when __debug__ is disabled.'.format(cls.__name__))
         super(DebugOnlyTestCase, cls).setUpClass()
 
 
@@ -1605,8 +1586,7 @@ class DeprecationTestCase(DebugOnlyTestCase, TestCase):
 
             if item.filename != filename:
                 self.fail(
-                    'expected warning filename %s; warning item: %s'
-                    % (filename, item))
+                    'expected warning filename {0!s}; warning item: {1!s}'.format(filename, item))
 
     def setUp(self):
         """Set up unit test."""

--- a/tests/bot_tests.py
+++ b/tests/bot_tests.py
@@ -30,8 +30,7 @@ class TWNBotTestCase(TestCase):
     def setUpClass(cls):
         """Verify that the translations are available."""
         if not i18n.messages_available():
-            raise unittest.SkipTest("i18n messages package '%s' not available."
-                                    % i18n._messages_package_name)
+            raise unittest.SkipTest("i18n messages package '{0!s}' not available.".format(i18n._messages_package_name))
         super(TWNBotTestCase, cls).setUpClass()
 
 

--- a/tests/date_tests.py
+++ b/tests/date_tests.py
@@ -37,8 +37,7 @@ class TestDateMeta(MetaTestCaseClass):
                     for value in range(start, stop, step):
                         self.assertTrue(
                             predicate(value),
-                            "date.formats['%s']['%s']:\ninvalid value %d"
-                            % (formatname, code, value))
+                            "date.formats['{0!s}']['{1!s}']:\ninvalid value {2:d}".format(formatname, code, value))
 
                         newValue = convFunc(convFunc(value))
                         self.assertEqual(

--- a/tests/dry_api_tests.py
+++ b/tests/dry_api_tests.py
@@ -172,7 +172,7 @@ class MockCachedRequestKeyTests(TestCase):
                 return "MockSite()"
 
             def __getattr__(self, attr):
-                raise Exception("Attribute %r not defined" % attr)
+                raise Exception("Attribute {0!r} not defined".format(attr))
 
         self.mocksite = MockSite()
         super(MockCachedRequestKeyTests, self).setUp()

--- a/tests/edit_failure_tests.py
+++ b/tests/edit_failure_tests.py
@@ -101,8 +101,7 @@ class TestActionFailure(TestCase):
             mysite.tokens['move']
         except KeyError:
             raise unittest.SkipTest(
-                "movepage test requires 'move' token not given to user on %s"
-                % self.site)
+                "movepage test requires 'move' token not given to user on {0!s}".format(self.site))
 
         self.assertRaises(Error, mysite.movepage,
                           mainpage, mainpage.title(), 'test')

--- a/tests/edit_tests.py
+++ b/tests/edit_tests.py
@@ -100,11 +100,11 @@ class OAuthEditTest(OAuthSiteTestCase):
         self.assertTrue(self.site.logged_in())
         ts = str(time.time())
         p = pywikibot.Page(self.site,
-                           'User:%s/edit test' % self.site.username())
+                           'User:{0!s}/edit test'.format(self.site.username()))
         p.site.editpage(p, appendtext=ts)
         revision_id = p.latest_revision_id
         p = pywikibot.Page(self.site,
-                           'User:%s/edit test' % self.site.username())
+                           'User:{0!s}/edit test'.format(self.site.username()))
         self.assertEqual(revision_id, p.latest_revision_id)
         self.assertTrue(p.text.endswith(ts))
 

--- a/tests/family_tests.py
+++ b/tests/family_tests.py
@@ -210,7 +210,7 @@ class TestFamilyUrlRegex(PatchingTestCase):
             family = Family.load(family)
             for code in family.codes:
                 self.current_code = code
-                url = ('%s://%s%s/$1' % (family.protocol(code),
+                url = ('{0!s}://{1!s}{2!s}/$1'.format(family.protocol(code),
                                          family.hostname(code),
                                          family.path(code)))
                 # Families can switch off if they want to be detected using URL

--- a/tests/i18n_tests.py
+++ b/tests/i18n_tests.py
@@ -131,8 +131,7 @@ class TWNTestCaseBase(TWNSetMessagePackageBase):
     def setUpClass(cls):
         """Verify that the test translations are not empty."""
         if not isinstance(cls.message_package, StringTypes):
-            raise TypeError('%s.message_package must be a package name'
-                            % cls.__name__)
+            raise TypeError('{0!s}.message_package must be a package name'.format(cls.__name__))
         # The call to set_messages_package below exists only to confirm
         # that the package exists and messages are available, so
         # that tests can be skipped if the i18n data doesnt exist.
@@ -141,8 +140,7 @@ class TWNTestCaseBase(TWNSetMessagePackageBase):
         has_messages = i18n.messages_available()
         i18n._messages_package_name = cls.orig_messages_package_name
         if not has_messages:
-            raise unittest.SkipTest("i18n messages package '%s' not available."
-                                    % cls.message_package)
+            raise unittest.SkipTest("i18n messages package '{0!s}' not available.".format(cls.message_package))
         super(TWNTestCaseBase, cls).setUpClass()
 
 
@@ -374,8 +372,7 @@ class InputTestCase(TWNTestCaseBase, UserInterfaceLangTestCase, PwbTestCase):
 
         if cls.code in i18n.twget_keys(cls.message):
             raise unittest.SkipTest(
-                '%s has a translation for %s'
-                % (cls.code, cls.message))
+                '{0!s} has a translation for {1!s}'.format(cls.code, cls.message))
 
     def test_pagegen_i18n_input(self):
         """Test i18n.input fallback via pwb and LC_ALL."""

--- a/tests/isbn_tests.py
+++ b/tests/isbn_tests.py
@@ -218,8 +218,7 @@ class TestIsbnWikibaseBot(ScriptMainTestCase, WikibaseTestCase, TWNBotTestCase):
                 u'%s: "ISBN-10" property was not found in '
                 u'"IsbnWikibaseBotUnitTest" item page' % cls.__name__)
         raise unittest.SkipTest(
-            u'%s: "IsbnWikibaseBotUnitTest" item page was not found'
-            % cls.__name__)
+            u'{0!s}: "IsbnWikibaseBotUnitTest" item page was not found'.format(cls.__name__))
 
     def setUp(self):
         """Patch Claim.setTarget and ItemPage.editEntity which write."""

--- a/tests/l10n_tests.py
+++ b/tests/l10n_tests.py
@@ -57,8 +57,7 @@ class TestValidTemplateMeta(MetaTestCaseClass):
 
         # create test methods for package messages processed by unittest
         if not i18n.messages_available():
-            raise unittest.SkipTest("i18n messages package '%s' not available."
-                                    % i18n._messages_package_name)
+            raise unittest.SkipTest("i18n messages package '{0!s}' not available.".format(i18n._messages_package_name))
 
         site = pywikibot.Site(dct['code'], dct['family'])
         codes = site.family.languages_by_size
@@ -67,7 +66,7 @@ class TestValidTemplateMeta(MetaTestCaseClass):
             keys = i18n.twget_keys(package)
             for code in codes:
                 current_site = pywikibot.Site(code, dct['family'])
-                test_name = ("test_%s_%s" % (package, code)).replace('-', '_')
+                test_name = ("test_{0!s}_{1!s}".format(package, code)).replace('-', '_')
                 cls.add_method(
                     dct, test_name, test_method(current_site),
                     doc_suffix='{0} and language {1}'.format(
@@ -102,8 +101,7 @@ class TestSites(TestCase):
             keys = i18n.twget_keys(package)
             for key in keys:
                 self.assertIn(key, languages,
-                              "'%s' - json key '%s' is not a site language"
-                              % (package, key))
+                              "'{0!s}' - json key '{1!s}' is not a site language".format(package, key))
 
 
 if __name__ == '__main__':

--- a/tests/logentry_tests.py
+++ b/tests/logentry_tests.py
@@ -111,7 +111,7 @@ class TestLogentriesMeta(MetaTestCaseClass):
 
         # create test methods for the support logtype classes
         for logtype in LogEntryFactory._logtypes:
-            cls.add_method(dct, 'test_%sEntry' % logtype.title(),
+            cls.add_method(dct, 'test_{0!s}Entry'.format(logtype.title()),
                            test_method(logtype))
 
         return super(TestLogentriesMeta, cls).__new__(cls, name, bases, dct)

--- a/tests/namespace_tests.py
+++ b/tests/namespace_tests.py
@@ -205,8 +205,7 @@ class TestNamespaceObject(TestCase):
         """Test Namespace.__repr__."""
         a = Namespace(id=0, canonical_name=u'Foo')
         s = repr(a)
-        r = "Namespace(id=0, custom_name=%r, canonical_name=%r, aliases=[])" \
-            % (unicode('Foo'), unicode('Foo'))
+        r = "Namespace(id=0, custom_name={0!r}, canonical_name={1!r}, aliases=[])".format(unicode('Foo'), unicode('Foo'))
         self.assertEqual(s, r)
 
         a.defaultcontentmodel = 'bar'

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -177,8 +177,7 @@ class TestPageObjectEnglish(TestCase):
         family_name = (site.family.name + ':'
                        if pywikibot.config2.family != site.family.name
                        else u'')
-        self.assertEqual(str(mainpage), u"[[%s%s:%s]]"
-                                        % (family_name, site.code,
+        self.assertEqual(str(mainpage), u"[[{0!s}{1!s}:{2!s}]]".format(family_name, site.code,
                                            mainpage.title()))
         self.assertLess(mainpage, maintalk)
 
@@ -418,8 +417,7 @@ class TestPageObject(DefaultSiteTestCase):
         mainpage = self.get_mainpage()
         maintalk = mainpage.toggleTalkPage()
         if not maintalk.exists():
-            raise unittest.SkipTest("No talk page for %s's main page"
-                                    % self.get_site())
+            raise unittest.SkipTest("No talk page for {0!s}'s main page".format(self.get_site()))
         self.assertIsInstance(maintalk.get(), unicode)
         self.assertEqual(mainpage.toggleTalkPage(), maintalk)
         self.assertEqual(maintalk.toggleTalkPage(), mainpage)
@@ -608,7 +606,7 @@ class TestPageRepr(TestPageBaseUnicode):
     def test_unicode_value_py3(self):
         """Test to capture actual Python 3 result pre unicode_literals."""
         self.assertEqual(repr(self.page), "Page('Ō')")
-        self.assertEqual('%r' % self.page, "Page('Ō')")
+        self.assertEqual('{0!r}'.format(self.page), "Page('Ō')")
         self.assertEqual('{0!r}'.format(self.page), "Page('Ō')")
 
     @unittest.skipIf(not PY2, 'Python 2 specific test')
@@ -659,8 +657,7 @@ class TestPageBotMayEdit(TestCase):
         page = pywikibot.Page(site, 'not_existent_page_for_pywikibot_tests')
         if page.exists():
             raise unittest.SkipTest(
-                "Page %s exists! Change page name in tests/page_tests.py"
-                % page.title())
+                "Page {0!s} exists! Change page name in tests/page_tests.py".format(page.title()))
 
         # Ban all compliant bots (shortcut).
         page.text = '{{nobots}}'
@@ -670,20 +667,17 @@ class TestPageBotMayEdit(TestCase):
         # Ban all compliant bots not in the list, syntax for de wp.
         page.text = '{{nobots|HagermanBot,Werdnabot}}'
         self.assertTrue(page.botMayEdit(),
-                        u'%s: %s but user=%s'
-                        % (page.text, page.botMayEdit(), user))
+                        u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all compliant bots not in the list, syntax for de wp.
-        page.text = '{{nobots|%s, HagermanBot,Werdnabot}}' % user
+        page.text = '{{{{nobots|{0!s}, HagermanBot,Werdnabot}}}}'.format(user)
         self.assertFalse(page.botMayEdit(),
-                         u'%s: %s but user=%s'
-                         % (page.text, page.botMayEdit(), user))
+                         u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all bots, syntax for de wp.
         page.text = '{{nobots|all}}'
         self.assertFalse(page.botMayEdit(),
-                         u'%s: %s but user=%s'
-                         % (page.text, page.botMayEdit(), user))
+                         u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Allow all bots (shortcut).
         page.text = '{{bots}}'
@@ -693,50 +687,42 @@ class TestPageBotMayEdit(TestCase):
         # Ban all compliant bots not in the list.
         page.text = '{{bots|allow=HagermanBot,Werdnabot}}'
         self.assertFalse(page.botMayEdit(),
-                         u'%s: %s but user=%s'
-                         % (page.text, page.botMayEdit(), user))
+                         u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all compliant bots in the list.
         page.text = '{{bots|deny=HagermanBot,Werdnabot}}'
         self.assertTrue(page.botMayEdit(),
-                        u'%s: %s but user=%s'
-                        % (page.text, page.botMayEdit(), user))
+                        u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all compliant bots not in the list.
-        page.text = '{{bots|allow=%s, HagermanBot}}' % user
+        page.text = '{{{{bots|allow={0!s}, HagermanBot}}}}'.format(user)
         self.assertTrue(page.botMayEdit(),
-                        u'%s: %s but user=%s'
-                        % (page.text, page.botMayEdit(), user))
+                        u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all compliant bots in the list.
-        page.text = '{{bots|deny=%s, HagermanBot}}' % user
+        page.text = '{{{{bots|deny={0!s}, HagermanBot}}}}'.format(user)
         self.assertFalse(page.botMayEdit(),
-                         u'%s: %s but user=%s'
-                         % (page.text, page.botMayEdit(), user))
+                         u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Allow all bots.
         page.text = '{{bots|allow=all}}'
         self.assertTrue(page.botMayEdit(),
-                        u'%s: %s but user=%s'
-                        % (page.text, page.botMayEdit(), user))
+                        u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all compliant bots.
         page.text = '{{bots|allow=none}}'
         self.assertFalse(page.botMayEdit(),
-                         u'%s: %s but user=%s'
-                         % (page.text, page.botMayEdit(), user))
+                         u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Ban all compliant bots.
         page.text = '{{bots|deny=all}}'
         self.assertFalse(page.botMayEdit(),
-                         u'%s: %s but user=%s'
-                         % (page.text, page.botMayEdit(), user))
+                         u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
         # Allow all bots.
         page.text = '{{bots|deny=none}}'
         self.assertTrue(page.botMayEdit(),
-                        u'%s: %s but user=%s'
-                        % (page.text, page.botMayEdit(), user))
+                        u'{0!s}: {1!s} but user={2!s}'.format(page.text, page.botMayEdit(), user))
 
 
 class TestPageHistory(DefaultSiteTestCase):

--- a/tests/pagegenerators_tests.py
+++ b/tests/pagegenerators_tests.py
@@ -178,7 +178,7 @@ class TestDryPageGenerators(TestCase):
                                                       site=self.site)
         pages = []
         for p in gen:
-            p.text = u"This is the content of %s as a sample" % p.title()
+            p.text = u"This is the content of {0!s} as a sample".format(p.title())
             pages.append(p)
         gen = pagegenerators.RegexBodyFilterPageGenerator(iter(pages), '/doc')
         self.assertPagelistTitles(gen,
@@ -1060,8 +1060,7 @@ class LiveRCPageGeneratorTestCase(RecentChangesTestCase):
 
         if LooseVersion(socketIO_client.__version__) >= LooseVersion('0.6.1'):
             raise unittest.SkipTest(
-                'socketIO_client %s not supported by Wikimedia-Stream'
-                % socketIO_client.__version__)
+                'socketIO_client {0!s} not supported by Wikimedia-Stream'.format(socketIO_client.__version__))
 
     def test_RC_pagegenerator_result(self):
         """Test RC pagegenerator."""

--- a/tests/paraminfo_tests.py
+++ b/tests/paraminfo_tests.py
@@ -81,7 +81,7 @@ class MediaWikiKnownTypesTestCase(KnownTypesTestBase,
         if MediaWikiVersion(self.site.version()) >= MediaWikiVersion('1.24'):
             types.append('unread')
 
-        known = types + ['!%s' % item for item in types]
+        known = types + ['!{0!s}'.format(item) for item in types]
 
         self._check_param_values(self.site, 'query+watchlist', 'show', known)
 

--- a/tests/pwb/print_env.py
+++ b/tests/pwb/print_env.py
@@ -20,7 +20,7 @@ for k, v in sorted(os.environ.items()):
     # This only appears in subprocesses
     if k in ['PYWIKIBOT2_DIR_PWB']:
         continue
-    print("%r: %r" % (k, v))
+    print("{0!r}: {1!r}".format(k, v))
 
 print('sys.path:')
 for path in sys.path:

--- a/tests/pwb/print_locals.py
+++ b/tests/pwb/print_locals.py
@@ -10,6 +10,6 @@ for k, v in sorted(locals().copy().items()):
     if k in ['__cached__', '__loader__', '__spec__']:
         continue
     if k == '__file__':
-        print("__file__: %r" % os.path.join('.', os.path.relpath(__file__)))
+        print("__file__: {0!r}".format(os.path.join('.', os.path.relpath(__file__))))
     else:
-        print("%r: %r" % (k, v))
+        print("{0!r}: {1!r}".format(k, v))

--- a/tests/script_tests.py
+++ b/tests/script_tests.py
@@ -64,8 +64,7 @@ def check_script_deps(script_name):
             try:
                 __import__(package_name)
             except ImportError as e:
-                print('%s depends on %s, which isnt available:\n%s'
-                      % (script_name, package_name, e))
+                print('{0!s} depends on {1!s}, which isnt available:\n{2!s}'.format(script_name, package_name, e))
                 return False
     return True
 
@@ -189,8 +188,7 @@ def collector(loader=unittest.loader.defaultTestLoader):
     # discover() ordering of unit tests.
 
     if unrunnable_script_list:
-        print('Skipping execution of unrunnable scripts:\n  %r'
-              % unrunnable_script_list)
+        print('Skipping execution of unrunnable scripts:\n  {0!r}'.format(unrunnable_script_list))
 
     if not enable_autorun_tests:
         print('Skipping execution of auto-run scripts '
@@ -308,14 +306,12 @@ class TestScriptMeta(MetaTestCaseClass):
                     exit_codes = [0, -9]
 
                     if (not result['stdout'] and not result['stderr']):
-                        print(' auto-run script unresponsive after %d seconds'
-                              % timeout, end=' ')
+                        print(' auto-run script unresponsive after {0:d} seconds'.format(timeout), end=' ')
                     elif 'SIMULATION: edit action blocked' in result['stderr']:
                         print(' auto-run script simulated edit blocked',
                               end='  ')
                     else:
-                        print(' auto-run script stderr within %d seconds: %r'
-                              % (timeout, result['stderr']), end='  ')
+                        print(' auto-run script stderr within {0:d} seconds: {1!r}'.format(timeout, result['stderr']), end='  ')
 
                 self.assertNotIn('Traceback (most recent call last)',
                                  result['stderr'])
@@ -356,7 +352,7 @@ class TestScriptMeta(MetaTestCaseClass):
 
             cls.add_method(dct, test_name,
                            test_execution(script_name, [argument]),
-                           'Test running %s %s.' % (script_name, argument))
+                           'Test running {0!s} {1!s}.'.format(script_name, argument))
 
             if script_name in dct['_expected_failures']:
                 dct[test_name] = unittest.expectedFailure(dct[test_name])

--- a/tests/site_tests.py
+++ b/tests/site_tests.py
@@ -271,7 +271,7 @@ class TestSiteObject(DefaultSiteTestCase):
         self.assertEqual(mysite, pywikibot.Site(self.code, self.family))
         self.assertIsInstance(mysite.user(), (basestring, type(None)))
         self.assertEqual(mysite.sitename(),
-                         "%s:%s" % (self.family,
+                         "{0!s}:{1!s}".format(self.family,
                                     self.code))
         self.assertIsInstance(mysite.linktrail(), basestring)
         self.assertIsInstance(mysite.redirect(), basestring)
@@ -413,7 +413,7 @@ class TestSiteObject(DefaultSiteTestCase):
         mysite = self.get_site()
         if mysite.lang != 'en':
             raise unittest.SkipTest(
-                'English-specific tests not valid on %s' % mysite)
+                'English-specific tests not valid on {0!s}'.format(mysite))
 
         self.assertEqual(mysite.months_names[4], (u'May', u'May'))
         self.assertEqual(mysite.list_to_text(('Pride', 'Prejudice')), 'Pride and Prejudice')
@@ -1012,8 +1012,7 @@ class TestImageUsage(DefaultSiteTestCase):
         else:
             raise unittest.SkipTest("No images on site {0!r}".format(mysite))
 
-        pywikibot.output(u'site_tests.TestImageUsage found %s on %s'
-                         % (imagepage, page))
+        pywikibot.output(u'site_tests.TestImageUsage found {0!s} on {1!s}'.format(imagepage, page))
 
         self.__class__._image_page = imagepage
         return imagepage
@@ -1367,7 +1366,7 @@ class SearchTestCase(DefaultSiteTestCase):
         super(SearchTestCase, self).setUp()
         if self.site.has_extension('Wikia Search'):
             raise unittest.SkipTest(
-                'The site %r does not use MediaWiki search' % self.site)
+                'The site {0!r} does not use MediaWiki search'.format(self.site))
 
     def testSearch(self):
         """Test the site.search() method."""
@@ -1393,7 +1392,7 @@ class SearchTestCase(DefaultSiteTestCase):
                 self.assertEqual(hit.namespace(), 0)
         except pywikibot.data.api.APIError as e:
             if e.code == "gsrsearch-error" and "timed out" in e.info:
-                raise unittest.SkipTest("gsrsearch returned timeout on site: %r" % e)
+                raise unittest.SkipTest("gsrsearch returned timeout on site: {0!r}".format(e))
             raise
 
     def test_search_where(self):
@@ -1853,8 +1852,7 @@ class PatrolTestCase(TokenTestBase, TestCase):
             raise
 
         if hasattr(mysite, u'_patroldisabled') and mysite._patroldisabled:
-            raise unittest.SkipTest(u'Patrolling is disabled on %s wiki.'
-                                    % mysite)
+            raise unittest.SkipTest(u'Patrolling is disabled on {0!s} wiki.'.format(mysite))
 
         result = result[0]
         self.assertIsInstance(result, dict)
@@ -1946,13 +1944,11 @@ class TestSiteTokens(DefaultSiteTestCase):
         """Test tokens."""
         if version and self._version < MediaWikiVersion(version):
             raise unittest.SkipTest(
-                u'Site %s version %s is too low for this tests.'
-                % (self.mysite, self._version))
+                u'Site {0!s} version {1!s} is too low for this tests.'.format(self.mysite, self._version))
 
         if version and self._version < MediaWikiVersion(test_version):
             raise unittest.SkipTest(
-                u'Site %s version %s is too low for this tests.'
-                % (self.mysite, self._version))
+                u'Site {0!s} version {1!s} is too low for this tests.'.format(self.mysite, self._version))
 
         self.mysite.version = lambda: test_version
 

--- a/tests/textlib_tests.py
+++ b/tests/textlib_tests.py
@@ -43,8 +43,7 @@ class TestSectionFunctions(TestCase):
 
     def setUp(self):
         """Setup tests."""
-        self.catresult1 = ('[[Category:Cat1]]%(LS)s[[Category:Cat2]]%(LS)s'
-                           % {'LS': config.LS})
+        self.catresult1 = ('[[Category:Cat1]]{LS!s}[[Category:Cat2]]{LS!s}'.format(**{'LS': config.LS}))
         super(TestSectionFunctions, self).setUp()
 
     def contains(self, fn, sn):
@@ -120,8 +119,7 @@ class TestFormatInterwiki(TestCase):
             'de': pywikibot.Page(pywikibot.Link('de:German', self.site)),
             'fr': pywikibot.Page(pywikibot.Link('fr:French', self.site))
         }
-        self.assertEqual('[[de:German]]%(LS)s[[fr:French]]%(LS)s'
-                         % {'LS': config.LS},
+        self.assertEqual('[[de:German]]{LS!s}[[fr:French]]{LS!s}'.format(**{'LS': config.LS}),
                          textlib.interwikiFormat(interwikis, self.site))
 
     def test_interwiki_format_Link(self):
@@ -130,8 +128,7 @@ class TestFormatInterwiki(TestCase):
             'de': pywikibot.Link('de:German', self.site),
             'fr': pywikibot.Link('fr:French', self.site),
         }
-        self.assertEqual('[[de:German]]%(LS)s[[fr:French]]%(LS)s'
-                         % {'LS': config.LS},
+        self.assertEqual('[[de:German]]{LS!s}[[fr:French]]{LS!s}'.format(**{'LS': config.LS}),
                          textlib.interwikiFormat(interwikis, self.site))
 
 
@@ -141,8 +138,7 @@ class TestFormatCategory(DefaultDrySiteTestCase):
 
     dry = True
 
-    catresult = ('[[Category:Cat1]]%(LS)s[[Category:Cat2]]%(LS)s'
-                 % {'LS': config.LS})
+    catresult = ('[[Category:Cat1]]{LS!s}[[Category:Cat2]]{LS!s}'.format(**{'LS': config.LS}))
 
     def test_category_format_raw(self):
         """Test formatting categories as strings formatted as links."""
@@ -1168,18 +1164,18 @@ class TestReplaceExcept(DefaultDrySiteTestCase):
     def test_replace_tag_category(self):
         """Test replacing not inside category links."""
         for ns_name in self.site.namespaces[14]:
-            self.assertEqual(textlib.replaceExcept('[[%s:x]]' % ns_name,
+            self.assertEqual(textlib.replaceExcept('[[{0!s}:x]]'.format(ns_name),
                                                    'x', 'y', ['category'],
                                                    site=self.site),
-                             '[[%s:x]]' % ns_name)
+                             '[[{0!s}:x]]'.format(ns_name))
 
     def test_replace_tag_file(self):
         """Test replacing not inside file links."""
         for ns_name in self.site.namespaces[6]:
-            self.assertEqual(textlib.replaceExcept('[[%s:x]]' % ns_name,
+            self.assertEqual(textlib.replaceExcept('[[{0!s}:x]]'.format(ns_name),
                                                    'x', 'y', ['file'],
                                                    site=self.site),
-                             '[[%s:x]]' % ns_name)
+                             '[[{0!s}:x]]'.format(ns_name))
 
         self.assertEqual(
             textlib.replaceExcept(
@@ -1292,8 +1288,7 @@ class TestReplaceExcept(DefaultDrySiteTestCase):
     def test_replace_tags_interwiki(self):
         """Test replacing not inside interwiki links."""
         if 'es' not in self.site.family.langs or 'ey' in self.site.family.langs:
-            raise unittest.SkipTest('family %s doesnt have languages'
-                                    % self.site)
+            raise unittest.SkipTest('family {0!s} doesnt have languages'.format(self.site))
 
         self.assertEqual(textlib.replaceExcept('[[es:s]]', 's', 't',
                                                ['interwiki'], site=self.site),

--- a/tests/tools_ip_tests.py
+++ b/tests/tools_ip_tests.py
@@ -49,8 +49,7 @@ class TestIPBase(TestCase):
         except AssertionError:
             self.fail += 1
             self.errors.append(
-                '"%s" match should be %s - not OK'
-                % (IP, result))
+                '"{0!s}" match should be {1!s} - not OK'.format(IP, result))
 
     def _run_tests(self):
         """Test various IP."""

--- a/tests/ui_options_tests.py
+++ b/tests/ui_options_tests.py
@@ -81,9 +81,9 @@ class TestChoiceOptions(TestCase):
         self.assertFalse(option.test('r6'))
         self.assertIsNone(option.handled('r6'))
         for i in range(1, 6):
-            self.assertTrue(option.test('r%d' % i))
-            self.assertEqual(option.handled('r%d' % i), option)
-            self.assertEqual(option.result('r%d' % i), ('r', i))
+            self.assertTrue(option.test('r{0:d}'.format(i)))
+            self.assertEqual(option.handled('r{0:d}'.format(i)), option)
+            self.assertEqual(option.result('r{0:d}'.format(i)), ('r', i))
 
     def test_List(self):
         """Test ListOption."""
@@ -107,15 +107,14 @@ class TestChoiceOptions(TestCase):
         for prefix in ('', 'r', 'st'):
             option = bot.ListOption(options, prefix=prefix)
             self.assertEqual(message('?', [option]),
-                             '? (%s<number> [1-3])' % prefix)
+                             '? ({0!s}<number> [1-3])'.format(prefix))
             for i, elem in enumerate(options, 1):
-                self.assertTrue(option.test('%s%d' % (prefix, i)))
-                self.assertIs(option.handled('%s%d' % (prefix, i)), option)
-                self.assertEqual(option.result('%s%d' % (prefix, i)),
+                self.assertTrue(option.test('{0!s}{1:d}'.format(prefix, i)))
+                self.assertIs(option.handled('{0!s}{1:d}'.format(prefix, i)), option)
+                self.assertEqual(option.result('{0!s}{1:d}'.format(prefix, i)),
                                  (prefix, elem))
-            self.assertFalse(option.test('%s%d' % (prefix, len(options) + 1)))
-            self.assertIsNone(option.handled('%s%d'
-                                             % (prefix, len(options) + 1)))
+            self.assertFalse(option.test('{0!s}{1:d}'.format(prefix, len(options) + 1)))
+            self.assertIsNone(option.handled('{0!s}{1:d}'.format(prefix, len(options) + 1)))
 
 
 if __name__ == '__main__':

--- a/tests/ui_tests.py
+++ b/tests/ui_tests.py
@@ -92,7 +92,7 @@ class Stream(object):
         patched_streams[self._original] = self._stream
 
     def __repr__(self):
-        return '<patched %s %r wrapping %r>' % (
+        return '<patched {0!s} {1!r} wrapping {2!r}>'.format(
             self._name, self._stream, self._original)
 
     def reset(self):
@@ -529,8 +529,7 @@ class WindowsTerminalTestCase(UITestCase):
             try:
                 cls._app = pywinauto.application.Application()
             except AttributeError as e2:
-                raise unittest.SkipTest('pywinauto Application failed: %s\n%s'
-                                        % (e1, e2))
+                raise unittest.SkipTest('pywinauto Application failed: {0!s}\n{1!s}'.format(e1, e2))
         super(WindowsTerminalTestCase, cls).setUpClass()
 
     @classmethod
@@ -547,15 +546,13 @@ class WindowsTerminalTestCase(UITestCase):
             window = cls._app.window_()
         except Exception as e:
             cls.tearDownProcess()
-            raise unittest.SkipTest('Windows package pywinauto could not locate window: %r'
-                                    % e)
+            raise unittest.SkipTest('Windows package pywinauto could not locate window: {0!r}'.format(e))
 
         try:
             window.TypeKeys('% {UP}{ENTER}%L{HOME}L{ENTER}', with_spaces=True)
         except Exception as e:
             cls.tearDownProcess()
-            raise unittest.SkipTest('Windows package pywinauto could not use window TypeKeys: %r'
-                                    % e)
+            raise unittest.SkipTest('Windows package pywinauto could not use window TypeKeys: {0!r}'.format(e))
 
     @classmethod
     def tearDownProcess(cls):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -403,8 +403,7 @@ class DryRequest(CachedRequest):
 
     def submit(self):
         """Prevented method."""
-        raise Exception(u'DryRequest rejecting request: %r'
-                        % self._params)
+        raise Exception(u'DryRequest rejecting request: {0!r}'.format(self._params))
 
 
 class DrySite(pywikibot.site.APISite):
@@ -453,8 +452,7 @@ class DrySite(pywikibot.site.APISite):
 
     def version(self):
         """Dummy version, with warning to show the callers context."""
-        warn('%r returning version 1.24; override if unsuitable.'
-             % self, DrySiteNote, stacklevel=2)
+        warn('{0!r} returning version 1.24; override if unsuitable.'.format(self), DrySiteNote, stacklevel=2)
         return '1.24'
 
     def image_repository(self):
@@ -848,14 +846,14 @@ def execute(command, data_in=None, timeout=0, error=None):
                            not isinstance(v, str)]
             if unicode_env:
                 raise TypeError(
-                    '%s: unicode in os.environ: %r' % (e, unicode_env))
+                    '{0!s}: unicode in os.environ: {1!r}'.format(e, unicode_env))
 
             child_unicode_env = [(k, v) for k, v in env.items()
                                  if not isinstance(k, str) or
                                  not isinstance(v, str)]
             if child_unicode_env:
                 raise TypeError(
-                    '%s: unicode in child env: %r' % (e, child_unicode_env))
+                    '{0!s}: unicode in child env: {1!r}'.format(e, child_unicode_env))
         raise
 
     if data_in is not None:
@@ -907,10 +905,9 @@ def execute_pwb(args, data_in=None, timeout=0, error=None, overrides=None):
     if overrides:
         command.append('-c')
         overrides = '; '.join(
-            '%s = %s' % (key, value) for key, value in overrides.items())
+            '{0!s} = {1!s}'.format(key, value) for key, value in overrides.items())
         command.append(
-            'import pwb; import pywikibot; %s; pwb.main()'
-            % overrides)
+            'import pwb; import pywikibot; {0!s}; pwb.main()'.format(overrides))
     else:
         command.append(_pwb_py)
 

--- a/tests/wikibase_tests.py
+++ b/tests/wikibase_tests.py
@@ -215,14 +215,14 @@ class TestWikibaseTypes(WikidataTestCase):
     def test_WbQuantity_formatting(self):
         """Test other WbQuantity methods."""
         q = pywikibot.WbQuantity(amount='0.044405586')
-        self.assertEqual("%s" % q,
+        self.assertEqual("{0!s}".format(q),
                          '{\n'
                          '    "amount": "+%(val)s",\n'
                          '    "lowerBound": "+%(val)s",\n'
                          '    "unit": "1",\n'
                          '    "upperBound": "+%(val)s"\n'
                          '}' % {'val': '0.044405586'})
-        self.assertEqual("%r" % q,
+        self.assertEqual("{0!r}".format(q),
                          "WbQuantity(amount=%(val)s, "
                          "upperBound=%(val)s, lowerBound=%(val)s, "
                          "unit=1)" % {'val': '0.044405586'})


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pywikibot-core?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pywikibot-core?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
